### PR TITLE
fix: gracefully ignore not implemented entities

### DIFF
--- a/custom_components/vimar_byme_plus/translations/en.json
+++ b/custom_components/vimar_byme_plus/translations/en.json
@@ -16,8 +16,8 @@
                 "description": "Do you want to start setup?"
             },
             "discovery_confirm": {
-                "title": "VIMAR By-me Plus HUB",
-                "description": "Please enter your Setup Code obtained from Vimar Pro app.\nRefer to the official documentation for additional info [here](https://github.com/andreaprosseda/vimar-byme-plus-homeassistant?tab=readme-ov-file#step-23-vimar-pro---initial-setup)"
+                "description": "Please enter your Setup Code obtained from Vimar Pro app.\nRefer to the official documentation for additional info [here](https://github.com/andreaprosseda/vimar-byme-plus-homeassistant?tab=readme-ov-file#step-23-vimar-pro---initial-setup)",
+                "title": "VIMAR By-me Plus HUB"
             },
             "user": {
                 "data": {

--- a/custom_components/vimar_byme_plus/vimar/mapper/access/access_mapper.py
+++ b/custom_components/vimar_byme_plus/vimar/mapper/access/access_mapper.py
@@ -4,6 +4,8 @@ from ..base_mapper import BaseMapper
 from ...model.repository.user_component import UserComponent
 from ...model.component.vimar_cover import VimarCover
 from ...model.enum.sftype_enum import SfType
+from ...utils.logger import not_implemented
+from ...utils.filtering import filter_none
 
 
 class AccessMapper:
@@ -11,12 +13,17 @@ class AccessMapper:
     def from_list(components: list[UserComponent]) -> list[VimarCover]:
         sftype = SfType.ACCESS.value
         shutters = [component for component in components if component.sftype == sftype]
-        return [AccessMapper.from_obj(shutter) for shutter in shutters]
+        components = [AccessMapper.from_obj(shutter) for shutter in shutters]
+        return filter_none(components)
 
     @staticmethod
     def from_obj(component: UserComponent, *args) -> VimarCover:
-        mapper = AccessMapper.get_mapper(component)
-        return mapper.from_obj(component, *args)
+        try:
+            mapper = AccessMapper.get_mapper(component)
+            return mapper.from_obj(component, *args)
+        except NotImplementedError:
+            not_implemented(component)
+            return None
 
     @staticmethod
     def get_mapper(component: UserComponent) -> BaseMapper:

--- a/custom_components/vimar_byme_plus/vimar/mapper/light/light_mapper.py
+++ b/custom_components/vimar_byme_plus/vimar/mapper/light/light_mapper.py
@@ -4,6 +4,8 @@ from ..base_mapper import BaseMapper
 from ...model.repository.user_component import UserComponent
 from ...model.component.vimar_light import VimarLight
 from ...model.enum.sftype_enum import SfType
+from ...utils.logger import not_implemented
+from ...utils.filtering import filter_none
 
 
 class LightMapper:
@@ -11,12 +13,17 @@ class LightMapper:
     def from_list(components: list[UserComponent]) -> list[VimarLight]:
         sftype = SfType.LIGHT.value
         lights = [component for component in components if component.sftype == sftype]
-        return [LightMapper.from_obj(light) for light in lights]
+        components = [LightMapper.from_obj(light) for light in lights]
+        return filter_none(components)
 
     @staticmethod
     def from_obj(component: UserComponent, *args) -> VimarLight:
-        mapper = LightMapper.get_mapper(component)
-        return mapper.from_obj(component, *args)
+        try:
+            mapper = LightMapper.get_mapper(component)
+            return mapper.from_obj(component, *args)
+        except NotImplementedError:
+            not_implemented(component)
+            return None
 
     @staticmethod
     def get_mapper(component: UserComponent) -> BaseMapper:

--- a/custom_components/vimar_byme_plus/vimar/mapper/shutter/shutter_mapper.py
+++ b/custom_components/vimar_byme_plus/vimar/mapper/shutter/shutter_mapper.py
@@ -4,6 +4,8 @@ from ..base_mapper import BaseMapper
 from ...model.repository.user_component import UserComponent
 from ...model.component.vimar_cover import VimarCover
 from ...model.enum.sftype_enum import SfType
+from ...utils.logger import not_implemented
+from ...utils.filtering import filter_none
 
 
 class ShutterMapper:
@@ -11,12 +13,17 @@ class ShutterMapper:
     def from_list(components: list[UserComponent]) -> list[VimarCover]:
         sftype = SfType.SHUTTER.value
         shutters = [component for component in components if component.sftype == sftype]
-        return [ShutterMapper.from_obj(shutter) for shutter in shutters]
+        components = [ShutterMapper.from_obj(shutter) for shutter in shutters]
+        return filter_none(components)
 
     @staticmethod
     def from_obj(component: UserComponent, *args) -> VimarCover:
-        mapper = ShutterMapper.get_mapper(component)
-        return mapper.from_obj(component, *args)
+        try:
+            mapper = ShutterMapper.get_mapper(component)
+            return mapper.from_obj(component, *args)
+        except NotImplementedError:
+            not_implemented(component)
+            return None
 
     @staticmethod
     def get_mapper(component: UserComponent) -> BaseMapper:

--- a/custom_components/vimar_byme_plus/vimar/utils/filtering.py
+++ b/custom_components/vimar_byme_plus/vimar/utils/filtering.py
@@ -1,0 +1,6 @@
+def filter_none(values: list):
+    result = []
+    for value in values:
+        if value:
+            result.append(value)
+    return result

--- a/custom_components/vimar_byme_plus/vimar/utils/logger.py
+++ b/custom_components/vimar_byme_plus/vimar/utils/logger.py
@@ -1,5 +1,6 @@
 import logging
 from .file import get_file_path, remove_file
+from ..model.repository.user_component import UserComponent
 
 formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
@@ -35,3 +36,10 @@ def log_debug(__name__: str, message: str):
 def log_error(__name__: str, message: str):
     logger.name = __name__
     logger.error(message)
+
+
+def not_implemented(component: UserComponent):
+    name = component.name
+    sstype = component.sstype
+    message = f"[{name}] Component of type {sstype} not yet implemented!"
+    log_error(__name__, message)


### PR DESCRIPTION
When the integration finds an entity that is not implemented, it raises an error and gives up aborting the setup.
With this fix, unimplemented entities are ignored