### PR TITLE
SS_Shutter_SlatWithoutPosition: fixed wrong SSTYPE 

### DIFF
--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/shutter/ss_shutter_slat_without_position_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/shutter/ss_shutter_slat_without_position_action_handler.py
@@ -11,7 +11,7 @@ SLAT = SfeType.CMD_SLAT_WITHOUT_POSITION
 
 
 class SsShutterSlatWithoutPositionActionHandler(SsShutterWithoutPositionActionHandler):
-    SSTYPE = SsType.SHUTTER_WITHOUT_POSITION.value
+    SSTYPE = SsType.SHUTTER_SLAT_WITHOUT_POSITION.value
 
     def get_actions(
         self, component: VimarComponent, action_type: ActionType, *args


### PR DESCRIPTION
wrong type representation of the SS_Shutter_SlatWithoutPosition (venetian blinds) component