### PR TITLE
Remove SS_Synoptic from “not implemented” error

### DIFF
--- a/custom_components/vimar_byme_plus/vimar/utils/logger.py
+++ b/custom_components/vimar_byme_plus/vimar/utils/logger.py
@@ -41,5 +41,6 @@ def log_error(module_name: str, message: str):
 def not_implemented(module_name: str, component: UserComponent):
     name = component.name
     sstype = component.sstype
-    message = f"[{name}] Component of type {sstype} not yet implemented!"
-    log_error(module_name, message)
+    if sstype != "SS_Synoptic":
+        message = f"[{name}] Component of type {sstype} not yet implemented!"
+        log_error(module_name, message)


### PR DESCRIPTION
SS_Synoptic components are intentionally out of scope for this library.
They are typically external components that are adapted to the specific Vimar context and are not part of the Vimar By-Me gateway component.
Equivalent functionality can be implemented directly in Home Assistant using native entities. For this reason, they are not meant to be managed by this integration.