### PR TITLE
fix: async_write_ha_state thread safety error resolved

### DIFF
--- a/custom_components/vimar_byme_plus/coordinator.py
+++ b/custom_components/vimar_byme_plus/coordinator.py
@@ -3,7 +3,8 @@
 import logging
 
 from websocket import WebSocketConnectionClosedException
-from homeassistant.core import HomeAssistant
+
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import ADDRESS, CODE, DOMAIN, GATEWAY_ID, GATEWAY_NAME, HOST, PORT, PROTOCOL
@@ -54,6 +55,7 @@ class Coordinator(DataUpdateCoordinator[VimarData]):
         """Update data when new status is received from the Gateway."""
         self.hass.add_job(self._update_data)
 
+    @callback
     def _update_data(self):
         data = self.client.retrieve_data()
         self.async_set_updated_data(data)


### PR DESCRIPTION
When an entity button was pressed (lights, climates, etc) the integration raised `RuntimeError: Detected that custom integration 'vimar_byme_plus' calls async_write_ha_state from a thread other than the event loop`.

This happened because `_update_data` ran in SyncWorker thread instead of the event loop.
When `hass.add_job()` receives a callable that is not decorated with `@callback`, Home Assistant schedules it in the thread pool. For this reason `async_set_updated_data` and listener callbacks (including `async_write_ha_state`) ran in the wrong thread.

With `@callback` decorator, `hass.add_job(self._update_data)` schedules it on the event loop
 In this way the whole update chain runs on the event loop and the thread safety error no longer occurs.