### PR TITLE
Multi-gateway support: 6 fixes (closes #34)

### DIFF
--- a/custom_components/vimar_byme_plus/__init__.py
+++ b/custom_components/vimar_byme_plus/__init__.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
+from .const import DOMAIN, GATEWAY_ID
 from .coordinator import Coordinator
 from .vimar.model.exceptions import CodeNotValidException, VimarErrorResponseException
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -43,6 +49,100 @@ async def async_unload_entry(
         entry.runtime_data.stop()
     entry.runtime_data = None
     return unload_ok
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, entry: ConfigEntry, device_entry
+) -> bool:
+    """Allow removing a single device via the HA UI without removing the config entry.
+
+    Returning True means: HA may detach this device from the config entry.
+    The next coordinator refresh will re-create the device only if the
+    Vimar gateway still publishes the corresponding idsf — so users can use
+    this to prune stale ghost devices left over from plant reconfigurations.
+    """
+    return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate config entry from previous schema versions.
+
+    v1 -> v2: scope device identifiers and entity unique_ids per gateway,
+    so that multi-gateway setups (issue #34) no longer collide on shared idsf.
+    """
+    _LOGGER.info(
+        "Migrating Vimar By-me Plus entry %s from version %s",
+        entry.title,
+        entry.version,
+    )
+
+    if entry.version < 2:
+        gateway_uid = entry.data.get(GATEWAY_ID) or entry.unique_id
+        if not gateway_uid:
+            _LOGGER.error(
+                "Cannot migrate entry %s: no gateway uid available", entry.entry_id
+            )
+            return False
+
+        device_reg = dr.async_get(hass)
+        entity_reg = er.async_get(hass)
+
+        # 1) Migrate device identifiers: (DOMAIN, idsf) -> (DOMAIN, f"{gw}_{idsf}")
+        migrated_devices = 0
+        for device in dr.async_entries_for_config_entry(device_reg, entry.entry_id):
+            new_identifiers: set[tuple[str, str]] = set()
+            changed = False
+            for ident in device.identifiers:
+                if ident[0] != DOMAIN:
+                    new_identifiers.add(ident)
+                    continue
+                value = ident[1]
+                value_str = str(value)
+                # Already migrated by a previous attempt — leave as-is
+                if isinstance(value, str) and value.startswith(f"{gateway_uid}_"):
+                    new_identifiers.add(ident)
+                    continue
+                new_identifiers.add((DOMAIN, f"{gateway_uid}_{value_str}"))
+                changed = True
+            if changed:
+                device_reg.async_update_device(
+                    device.id, new_identifiers=new_identifiers
+                )
+                migrated_devices += 1
+
+        # 2) Migrate entity unique_ids: vimar_byme_plus_app_<idsf>
+        #    -> vimar_byme_plus_<gw>_app_<idsf>
+        old_prefix = f"{DOMAIN}_app_"
+        new_prefix = f"{DOMAIN}_{gateway_uid}_app_"
+        migrated_entities = 0
+        for entity in er.async_entries_for_config_entry(entity_reg, entry.entry_id):
+            uid = entity.unique_id or ""
+            if not uid.startswith(old_prefix):
+                continue
+            idsf = uid[len(old_prefix):]
+            new_uid = f"{new_prefix}{idsf}"
+            try:
+                entity_reg.async_update_entity(entity.entity_id, new_unique_id=new_uid)
+                migrated_entities += 1
+            except ValueError:
+                # collision: another entity already has the new unique_id
+                # (rare — only happens if a previous failed migration left
+                # both versions). Keep old, will be cleaned up by user.
+                _LOGGER.warning(
+                    "Could not migrate entity %s to %s (collision)",
+                    entity.entity_id,
+                    new_uid,
+                )
+
+        hass.config_entries.async_update_entry(entry, version=2)
+        _LOGGER.info(
+            "Migration complete for %s: %s devices, %s entities updated",
+            entry.title,
+            migrated_devices,
+            migrated_entities,
+        )
+
+    return True
 
 
 async def start(coordinator: Coordinator):

--- a/custom_components/vimar_byme_plus/__init__.py
+++ b/custom_components/vimar_byme_plus/__init__.py
@@ -8,9 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from .const import DOMAIN, GATEWAY_ID
 from .coordinator import Coordinator
 from .vimar.model.exceptions import CodeNotValidException, VimarErrorResponseException
 
@@ -65,83 +63,38 @@ async def async_remove_config_entry_device(
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Migrate config entry from previous schema versions.
+    """Migrate config entry to schema version 2.
 
-    v1 -> v2: scope device identifiers and entity unique_ids per gateway,
-    so that multi-gateway setups (issue #34) no longer collide on shared idsf.
+    v1 -> v2: schema bump only. The integration now scopes device identifiers
+    and entity unique_ids per gateway (see base_entity.py — issue #34), but
+    we intentionally do **not** rewrite existing registry rows automatically
+    here. An automatic in-place rename is fragile in real-world installs
+    that may have user-renamed entity_ids, disabled-but-orphan rows, or
+    leftovers from past plant reconfigurations — failure modes are tricky
+    to recover from on the user side.
+
+    Upgrade path for existing single-gateway installs:
+      * On startup, the integration will publish entities with the new
+        gateway-scoped unique_ids. Old non-scoped registry rows are left
+        in place but become unavailable (no integration emits their uid
+        anymore). Users can remove them from the UI at their convenience.
+      * If preserving entity_ids / automation references matters, the
+        cleanest path is: remove the config entry and re-pair. This
+        recreates everything fresh under the new scheme.
+
+    Multi-gateway installs that suffered from the pre-fix collision MUST
+    re-pair (the registry contains genuinely ambiguous rows that no
+    automatic migration can disambiguate).
     """
-    _LOGGER.info(
-        "Migrating Vimar By-me Plus entry %s from version %s",
-        entry.title,
-        entry.version,
-    )
-
     if entry.version < 2:
-        gateway_uid = entry.data.get(GATEWAY_ID) or entry.unique_id
-        if not gateway_uid:
-            _LOGGER.error(
-                "Cannot migrate entry %s: no gateway uid available", entry.entry_id
-            )
-            return False
-
-        device_reg = dr.async_get(hass)
-        entity_reg = er.async_get(hass)
-
-        # 1) Migrate device identifiers: (DOMAIN, idsf) -> (DOMAIN, f"{gw}_{idsf}")
-        migrated_devices = 0
-        for device in dr.async_entries_for_config_entry(device_reg, entry.entry_id):
-            new_identifiers: set[tuple[str, str]] = set()
-            changed = False
-            for ident in device.identifiers:
-                if ident[0] != DOMAIN:
-                    new_identifiers.add(ident)
-                    continue
-                value = ident[1]
-                value_str = str(value)
-                # Already migrated by a previous attempt — leave as-is
-                if isinstance(value, str) and value.startswith(f"{gateway_uid}_"):
-                    new_identifiers.add(ident)
-                    continue
-                new_identifiers.add((DOMAIN, f"{gateway_uid}_{value_str}"))
-                changed = True
-            if changed:
-                device_reg.async_update_device(
-                    device.id, new_identifiers=new_identifiers
-                )
-                migrated_devices += 1
-
-        # 2) Migrate entity unique_ids: vimar_byme_plus_app_<idsf>
-        #    -> vimar_byme_plus_<gw>_app_<idsf>
-        old_prefix = f"{DOMAIN}_app_"
-        new_prefix = f"{DOMAIN}_{gateway_uid}_app_"
-        migrated_entities = 0
-        for entity in er.async_entries_for_config_entry(entity_reg, entry.entry_id):
-            uid = entity.unique_id or ""
-            if not uid.startswith(old_prefix):
-                continue
-            idsf = uid[len(old_prefix):]
-            new_uid = f"{new_prefix}{idsf}"
-            try:
-                entity_reg.async_update_entity(entity.entity_id, new_unique_id=new_uid)
-                migrated_entities += 1
-            except ValueError:
-                # collision: another entity already has the new unique_id
-                # (rare — only happens if a previous failed migration left
-                # both versions). Keep old, will be cleaned up by user.
-                _LOGGER.warning(
-                    "Could not migrate entity %s to %s (collision)",
-                    entity.entity_id,
-                    new_uid,
-                )
-
-        hass.config_entries.async_update_entry(entry, version=2)
         _LOGGER.info(
-            "Migration complete for %s: %s devices, %s entities updated",
+            "Bumping Vimar By-me Plus entry '%s' to schema v2 (gateway-scoped "
+            "identifiers). Existing entities will be replaced with scoped "
+            "versions on next coordinator refresh; orphan rows can be cleaned "
+            "from the UI.",
             entry.title,
-            migrated_devices,
-            migrated_entities,
         )
-
+        hass.config_entries.async_update_entry(entry, version=2)
     return True
 
 

--- a/custom_components/vimar_byme_plus/base_entity.py
+++ b/custom_components/vimar_byme_plus/base_entity.py
@@ -43,9 +43,24 @@ class BaseEntity(CoordinatorEntity):
         return self._component.device_class
 
     @property
+    def _gateway_id(self):
+        """Return the gateway deviceuid for scoping unique ids per gateway.
+
+        This is required for multi-gateway setups: Vimar `idsf` is per-plant
+        (per-gateway), not globally unique. Without this scoping, two gateways
+        publishing the same idsf would have their devices merged in HA's
+        device registry, causing the well-known "second gateway breaks the
+        first" issue (see issue #34).
+        """
+        try:
+            return self.coordinator.gateway_info.deviceuid
+        except Exception:
+            return "default"
+
+    @property
     def unique_id(self):
-        """Return unique id of the device."""
-        return DOMAIN + "_app_" + str(self._component.id)
+        """Return unique id of the device, scoped per gateway."""
+        return f"{DOMAIN}_{self._gateway_id}_app_{self._component.id}"
 
     @property
     def is_default_state(self):
@@ -54,9 +69,10 @@ class BaseEntity(CoordinatorEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        """Return device registry information for this entity."""
+        """Return device registry information for this entity (scoped per gateway)."""
+        scoped_id = f"{self._gateway_id}_{self._component.id}"
         return DeviceInfo(
-            identifiers={(DOMAIN, self._component.id)},
+            identifiers={(DOMAIN, scoped_id)},
             manufacturer=MANIFACTURER,
             name=self._component.name,
             model=self._component.device_name,
@@ -78,16 +94,3 @@ class BaseEntity(CoordinatorEntity):
         except VimarErrorResponseException as err:
             message = f"Error received from Gateway: {err.message}"
             raise HomeAssistantError(message) from err
-
-    @property
-    def should_poll(self) -> bool:
-        """Return True if entity has to be polled for state. False if entity pushes its state to HA."""
-        return False
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle device update."""
-        if self._component:
-            data: VimarData = self.coordinator.data
-            self._component = data.get_by_id(self._component.id)
-            self.async_write_ha_state()

--- a/custom_components/vimar_byme_plus/config_flow.py
+++ b/custom_components/vimar_byme_plus/config_flow.py
@@ -43,7 +43,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     discovery_info: zeroconf.ZeroconfServiceInfo = None
 
-    VERSION = 1
+    VERSION = 2
 
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 

--- a/custom_components/vimar_byme_plus/manifest.json
+++ b/custom_components/vimar_byme_plus/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/andreaprosseda/vimar-byme-plus-homeassistant/issues",
   "requirements": ["websocket-client"],
-  "version": "3.2.0",
+  "version": "3.2.1",
   "zeroconf": ["_vimar-devctrl._tcp.local."]
 }

--- a/custom_components/vimar_byme_plus/manifest.json
+++ b/custom_components/vimar_byme_plus/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/andreaprosseda/vimar-byme-plus-homeassistant/issues",
   "requirements": ["websocket-client"],
-  "version": "3.2.1",
+  "version": "3.2.2",
   "zeroconf": ["_vimar-devctrl._tcp.local."]
 }

--- a/custom_components/vimar_byme_plus/manifest.json
+++ b/custom_components/vimar_byme_plus/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/andreaprosseda/vimar-byme-plus-homeassistant/issues",
   "requirements": ["websocket-client"],
-  "version": "3.2.2",
+  "version": "3.2.3",
   "zeroconf": ["_vimar-devctrl._tcp.local."]
 }

--- a/custom_components/vimar_byme_plus/manifest.json
+++ b/custom_components/vimar_byme_plus/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/andreaprosseda/vimar-byme-plus-homeassistant/issues",
   "requirements": ["websocket-client"],
-  "version": "3.1.0",
+  "version": "3.2.0",
   "zeroconf": ["_vimar-devctrl._tcp.local."]
 }

--- a/custom_components/vimar_byme_plus/manifest.json
+++ b/custom_components/vimar_byme_plus/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/andreaprosseda/vimar-byme-plus-homeassistant/issues",
   "requirements": ["websocket-client"],
-  "version": "3.0.5",
+  "version": "3.1.0",
   "zeroconf": ["_vimar-devctrl._tcp.local."]
 }

--- a/custom_components/vimar_byme_plus/manifest.json
+++ b/custom_components/vimar_byme_plus/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/andreaprosseda/vimar-byme-plus-homeassistant/issues",
   "requirements": ["websocket-client"],
-  "version": "3.2.3",
+  "version": "3.2.4",
   "zeroconf": ["_vimar-devctrl._tcp.local."]
 }

--- a/custom_components/vimar_byme_plus/vimar/client/vimar_client.py
+++ b/custom_components/vimar_byme_plus/vimar/client/vimar_client.py
@@ -62,7 +62,8 @@ class VimarClient:
 
     def retrieve_data(self) -> VimarData:
         """Get the latest data from DB."""
-        components = self._component_repo.get_all()
+        gateway_uid = self._operational_service.gateway_info.deviceuid
+        components = self._component_repo.get_all(gateway_uid=gateway_uid)
         return VimarDataMapper.from_list(components)
 
     def get_gateway_info(self) -> GatewayInfo:
@@ -72,14 +73,18 @@ class VimarClient:
         return self._operational_service.gateway_info is not None
 
     def has_credentials(self) -> bool:
-        credentials = self._user_repo.get_current_user()
+        gateway_uid = self._operational_service.gateway_info.deviceuid
+        credentials = self._user_repo.get_current_user(gateway_uid=gateway_uid)
         return credentials and credentials.password is not None
 
     def set_setup_code(self, setup_code: str):
         if not setup_code:
             return
         self.validate_code(setup_code)
-        self._user_repo.insert_setup_code(USERNAME, setup_code)
+        gateway_uid = self._operational_service.gateway_info.deviceuid
+        self._user_repo.insert_setup_code(
+            USERNAME, setup_code, gateway_uid=gateway_uid
+        )
 
     def same_code(self, setup_code: str, current_user: UserCredentials) -> bool:
         if not current_user:

--- a/custom_components/vimar_byme_plus/vimar/database/database.py
+++ b/custom_components/vimar_byme_plus/vimar/database/database.py
@@ -1,3 +1,4 @@
+import os
 import sqlite3
 from sqlite3 import Connection, Error
 from typing import Optional
@@ -37,10 +38,31 @@ class Database:
         self.ambient_repo = AmbientRepo(conn)
         self.user_repo = UserRepo(conn)
         self.component_repo = ComponentRepo(conn, self.element_repo)
+        # Defensive: explicitly commit the CREATE TABLE statements run by each
+        # repo's __init__. Without this, an exception later in setup may leave
+        # the SQLite file as 0 bytes (no schema flushed to disk), and every
+        # subsequent reconnect re-opens an empty file. See discussion in #34.
+        try:
+            conn.commit()
+        except Error as e:
+            log_error(__name__, f"Could not commit schema: {e}")
 
     def create_connection(self) -> Connection:
         try:
             file_path = get_file_path(DATABASE_NAME)
+            # Self-heal: if a previous failed init left a 0-byte file,
+            # remove it so SQLite can write a fresh schema. Otherwise we
+            # would keep reopening the empty file forever and the integration
+            # would never reach the operational phase.
+            try:
+                if os.path.exists(file_path) and os.path.getsize(file_path) == 0:
+                    os.remove(file_path)
+                    log_info(
+                        __name__,
+                        f"Removed empty {DATABASE_NAME} left by a previous failed init",
+                    )
+            except OSError as e:
+                log_error(__name__, f"Could not remove empty db file: {e}")
             self._connection = sqlite3.connect(file_path, check_same_thread=False)
             log_info(__name__, "Connection to SQLite DB successful")
             return self._connection

--- a/custom_components/vimar_byme_plus/vimar/database/database.py
+++ b/custom_components/vimar_byme_plus/vimar/database/database.py
@@ -1,5 +1,6 @@
 import os
 import sqlite3
+import threading
 from sqlite3 import Connection, Error
 from typing import Optional
 
@@ -11,6 +12,24 @@ from .repository.element_repo import ElementRepo
 from .repository.user_repo import UserRepo
 
 DATABASE_NAME = "home.db"
+
+# Thread-local gateway scope. Each coordinator runs in its own thread; the
+# coordinator sets its gateway uid here on connect so repos and message
+# handlers can filter rows belonging to *this* gateway without every method
+# having to forward an extra argument. Without scoping, the second gateway's
+# pair wipes the first one's users/components/elements rows from the shared
+# singleton DB (issue #34, Bug #3).
+_thread_local = threading.local()
+
+
+def set_current_gateway_uid(gateway_uid: Optional[str]) -> None:
+    """Set the active gateway_uid for this thread (None clears it)."""
+    _thread_local.gateway_uid = gateway_uid
+
+
+def current_gateway_uid() -> Optional[str]:
+    """Return the active gateway_uid for this thread, or None if not set."""
+    return getattr(_thread_local, "gateway_uid", None)
 
 
 class Database:

--- a/custom_components/vimar_byme_plus/vimar/database/repository/ambient_repo.py
+++ b/custom_components/vimar_byme_plus/vimar/database/repository/ambient_repo.py
@@ -1,4 +1,5 @@
 from sqlite3 import Connection
+from typing import Optional
 
 from ...model.repository.user_ambient import UserAmbient
 from .base_repo import BaseRepo
@@ -8,6 +9,7 @@ class AmbientRepo(BaseRepo):
     def __init__(self, connection: Connection):
         super().__init__(connection)
         self.create_table()
+        self.alter_table()
 
     def create_table(self):
         query = """
@@ -17,37 +19,67 @@ class AmbientRepo(BaseRepo):
                 hash TEXT NOT NULL,
                 idambient INTEGER NOT NULL,
                 idparent INTEGER,
-                name TEXT NOT NULL
+                name TEXT NOT NULL,
+                gateway_uid TEXT
             );
             """
         self.execute(query)
 
-    def get_ids(self) -> list[int]:
-        query = "SELECT idambient FROM ambients;"
+    def alter_table(self):
+        query = "PRAGMA table_info(ambients);"
         cursor = self.cursor().execute(query)
+        columns = [column[1] for column in cursor.fetchall()]
+        if "gateway_uid" not in columns:
+            cursor.execute("ALTER TABLE ambients ADD COLUMN gateway_uid TEXT;")
+
+    def get_ids(self, gateway_uid: Optional[str] = None) -> list[int]:
+        if gateway_uid:
+            query = "SELECT idambient FROM ambients WHERE gateway_uid = ? OR gateway_uid IS NULL;"
+            cursor = self.cursor().execute(query, (gateway_uid,))
+        else:
+            query = "SELECT idambient FROM ambients;"
+            cursor = self.cursor().execute(query)
         record = cursor.fetchall()
         return record if record else []
 
-    def replace_all(self, ambients: list[UserAmbient]):
-        self.delete_all()
-        self.insert_all(ambients)
+    def replace_all(
+        self, ambients: list[UserAmbient], gateway_uid: Optional[str] = None
+    ):
+        # Only wipe rows for *this* gateway, otherwise the second gateway's
+        # ambient discovery would erase the first gateway's ambients and
+        # break the components<->ambients JOIN in component_repo.get_all
+        # (issue #34, BUG#3 — ambients-scoping completion).
+        self.delete_all(gateway_uid=gateway_uid)
+        self.insert_all(ambients, gateway_uid=gateway_uid)
 
-    def delete_all(self):
-        query = "DELETE FROM ambients;"
-        self.execute(query)
+    def delete_all(self, gateway_uid: Optional[str] = None):
+        if gateway_uid:
+            query = "DELETE FROM ambients WHERE gateway_uid = ? OR gateway_uid IS NULL;"
+            self.execute(query, (gateway_uid,))
+        else:
+            query = "DELETE FROM ambients;"
+            self.execute(query)
 
-    def insert_all(self, ambients: list[UserAmbient]):
-        ambients_data = [ambient.to_tuple() for ambient in ambients]
+    def insert_all(
+        self, ambients: list[UserAmbient], gateway_uid: Optional[str] = None
+    ):
+        ambients_data = [(*ambient.to_tuple(), gateway_uid) for ambient in ambients]
         query = """
             INSERT INTO ambients
-                (dictKey, hash, idambient, idparent, name)
+                (dictKey, hash, idambient, idparent, name, gateway_uid)
             VALUES
-                (?, ?, ?, ?, ?);
+                (?, ?, ?, ?, ?, ?);
         """
         self.execute(query, ambients_data)
 
-    def get_name_by_id(self, idambient: int) -> str:
-        query = "SELECT name FROM ambients WHERE idambient = ?;"
-        cursor = self.cursor().execute(query, (idambient,))
+    def get_name_by_id(
+        self, idambient: int, gateway_uid: Optional[str] = None
+    ) -> str:
+        if gateway_uid:
+            query = "SELECT name FROM ambients WHERE idambient = ? AND (gateway_uid = ? OR gateway_uid IS NULL);"
+            cursor = self.cursor().execute(query, (idambient, gateway_uid))
+        else:
+            query = "SELECT name FROM ambients WHERE idambient = ?;"
+            cursor = self.cursor().execute(query, (idambient,))
         result = cursor.fetchone()
         return result[0] if result else None

--- a/custom_components/vimar_byme_plus/vimar/database/repository/base_repo.py
+++ b/custom_components/vimar_byme_plus/vimar/database/repository/base_repo.py
@@ -1,3 +1,4 @@
+import threading
 from sqlite3 import Connection, Cursor, Error
 
 from ...utils.logger import log_debug, log_error
@@ -6,6 +7,25 @@ from ...utils.logger import log_debug, log_error
 class BaseRepo:
     _connection: Connection
 
+    # Class-level lock guarding the shared sqlite3 Connection.
+    #
+    # Every repo instance receives the same `Database.instance()` connection,
+    # which is opened with `check_same_thread=False` so it can be used from
+    # the WS callback threads of multiple OperationalService coordinators.
+    # Without serialisation, two coordinators starting up at the same time
+    # (e.g. right after an HA restart with two paired gateways) interleave
+    # `cursor.execute() + connection.commit()` calls on the same Connection,
+    # which sqlite3 surfaces as `cannot start a transaction within a
+    # transaction` / `bad parameter or other API misuse`. The integration
+    # then loses some of the schema/state writes (visible symptom: doubled
+    # `components` rows after sfdiscovery, entities stuck `unavailable`
+    # until the user manually reloads the config entries from the UI).
+    #
+    # Holding the lock around the entire execute → commit pair is the
+    # smallest correct fix; the operations are short and not on the hot
+    # path so the contention is negligible.
+    _lock = threading.Lock()
+
     def __init__(self, connection: Connection):
         self._connection = connection
 
@@ -13,16 +33,17 @@ class BaseRepo:
         return self._connection.cursor()
 
     def execute(self, query, params: tuple = ()):
-        cursor = self.cursor()
-        try:
-            log_debug(__name__, f"Executing query: {query} with params: {params}")
-            if params and isinstance(params, (tuple)):
-                cursor.execute(query, params)
-            elif params and isinstance(params, list):
-                cursor.executemany(query, params)
-            else:
-                cursor.execute(query)
-            self._connection.commit()
-            log_debug(__name__, "Query executed successfully")
-        except Error as e:
-            log_error(__name__, f"The error '{e}' occurred")
+        with self._lock:
+            cursor = self.cursor()
+            try:
+                log_debug(__name__, f"Executing query: {query} with params: {params}")
+                if params and isinstance(params, (tuple)):
+                    cursor.execute(query, params)
+                elif params and isinstance(params, list):
+                    cursor.executemany(query, params)
+                else:
+                    cursor.execute(query)
+                self._connection.commit()
+                log_debug(__name__, "Query executed successfully")
+            except Error as e:
+                log_error(__name__, f"The error '{e}' occurred")

--- a/custom_components/vimar_byme_plus/vimar/database/repository/component_repo.py
+++ b/custom_components/vimar_byme_plus/vimar/database/repository/component_repo.py
@@ -84,6 +84,9 @@ class ComponentRepo(BaseRepo):
         # Join elements/ambients also filtered by gateway_uid where applicable.
         # Same-idsf collisions across gateways are now safe because both
         # components and elements carry the gateway_uid scope.
+        # LEFT JOIN on ambients so a missing/wiped ambient row never drops
+        # the component (defensive: ambient discovery for a different gateway
+        # used to wipe rows globally — see issue #34 BUG#3 ambients-scoping).
         if gateway_uid:
             query = """
                 SELECT
@@ -95,8 +98,9 @@ class ComponentRepo(BaseRepo):
                 JOIN
                     elements e ON c.idsf = e.idcomponent
                     AND (e.gateway_uid = c.gateway_uid OR e.gateway_uid IS NULL)
-                JOIN
+                LEFT JOIN
                     ambients a ON c.idambient = a.idambient
+                    AND (a.gateway_uid = c.gateway_uid OR a.gateway_uid IS NULL)
                 WHERE
                     c.gateway_uid = ? OR c.gateway_uid IS NULL;
             """
@@ -111,7 +115,7 @@ class ComponentRepo(BaseRepo):
                     components c
                 JOIN
                     elements e ON c.idsf = e.idcomponent
-                JOIN
+                LEFT JOIN
                     ambients a ON c.idambient = a.idambient;
             """
             cursor = self.cursor().execute(query)

--- a/custom_components/vimar_byme_plus/vimar/database/repository/component_repo.py
+++ b/custom_components/vimar_byme_plus/vimar/database/repository/component_repo.py
@@ -1,5 +1,5 @@
 from sqlite3 import Connection
-from typing import Any
+from typing import Any, Optional
 
 from ...model.repository.user_ambient import UserAmbient
 from ...model.repository.user_component import UserComponent
@@ -14,6 +14,7 @@ class ComponentRepo(BaseRepo):
     def __init__(self, connection: Connection, element_repo: ElementRepo):
         super().__init__(connection)
         self.create_table()
+        self.alter_table()
         self.element_repo = element_repo
 
     def create_table(self):
@@ -26,63 +27,114 @@ class ComponentRepo(BaseRepo):
                 name TEXT NOT NULL,
                 sftype TEXT NOT NULL,
                 sstype TEXT NOT NULL,
+                gateway_uid TEXT,
                 FOREIGN KEY (idambient) REFERENCES ambients (idambient)
             );
             """
         self.execute(query)
 
-    def replace_all(self, components: list[UserComponent]):
-        self.delete_all()
-        self.insert_all(components)
+    def alter_table(self):
+        query = "PRAGMA table_info(components);"
+        cursor = self.cursor().execute(query)
+        columns = [column[1] for column in cursor.fetchall()]
+        if "gateway_uid" not in columns:
+            cursor.execute("ALTER TABLE components ADD COLUMN gateway_uid TEXT;")
 
-    def delete_all(self):
-        self.element_repo.delete_all()
-        self._delete_all()
+    def replace_all(
+        self, components: list[UserComponent], gateway_uid: Optional[str] = None
+    ):
+        # Only wipe rows belonging to *this* gateway, so other paired gateways
+        # keep their components in the shared DB (issue #34, BUG#3).
+        self.delete_all(gateway_uid=gateway_uid)
+        self.insert_all(components, gateway_uid=gateway_uid)
 
-    def _delete_all(self):
-        query = "DELETE FROM components;"
-        self.execute(query)
+    def delete_all(self, gateway_uid: Optional[str] = None):
+        self.element_repo.delete_all(gateway_uid=gateway_uid)
+        self._delete_all(gateway_uid=gateway_uid)
 
-    def insert_all(self, components: list[UserComponent]):
-        self._insert_all(components)
-        self.element_repo.insert_all(components)
+    def _delete_all(self, gateway_uid: Optional[str] = None):
+        if gateway_uid:
+            query = "DELETE FROM components WHERE gateway_uid = ? OR gateway_uid IS NULL;"
+            self.execute(query, (gateway_uid,))
+        else:
+            query = "DELETE FROM components;"
+            self.execute(query)
 
-    def _insert_all(self, components: list[UserComponent]):
-        components_data = [component.to_tuple() for component in components]
+    def insert_all(
+        self, components: list[UserComponent], gateway_uid: Optional[str] = None
+    ):
+        self._insert_all(components, gateway_uid=gateway_uid)
+        self.element_repo.insert_all(components, gateway_uid=gateway_uid)
+
+    def _insert_all(
+        self, components: list[UserComponent], gateway_uid: Optional[str] = None
+    ):
+        components_data = [
+            (*component.to_tuple(), gateway_uid) for component in components
+        ]
         query = """
             INSERT INTO components
-                (dictKey, idambient, idsf, name, sftype, sstype)
+                (dictKey, idambient, idsf, name, sftype, sstype, gateway_uid)
             VALUES
-                (?, ?, ?, ?, ?, ?);
+                (?, ?, ?, ?, ?, ?, ?);
         """
         self.execute(query, components_data)
 
-    def get_all(self) -> list[UserComponent]:
-        query = """
-            SELECT
-                c.dictKey, c.idambient, c.idsf, c.name, c.sftype, c.sstype,
-                e.id, e.enable, e.sfetype, e.value, e.updated,
-                a.dictKey, a.hash, a.idambient, a.idparent, a.name
-            FROM
-                components c
-            JOIN
-                elements e ON c.idsf = e.idcomponent
-            JOIN
-                ambients a ON c.idambient = a.idambient;
-
-        """
-        cursor = self.cursor().execute(query)
+    def get_all(self, gateway_uid: Optional[str] = None) -> list[UserComponent]:
+        # Join elements/ambients also filtered by gateway_uid where applicable.
+        # Same-idsf collisions across gateways are now safe because both
+        # components and elements carry the gateway_uid scope.
+        if gateway_uid:
+            query = """
+                SELECT
+                    c.dictKey, c.idambient, c.idsf, c.name, c.sftype, c.sstype,
+                    e.id, e.enable, e.sfetype, e.value, e.updated,
+                    a.dictKey, a.hash, a.idambient, a.idparent, a.name
+                FROM
+                    components c
+                JOIN
+                    elements e ON c.idsf = e.idcomponent
+                    AND (e.gateway_uid = c.gateway_uid OR e.gateway_uid IS NULL)
+                JOIN
+                    ambients a ON c.idambient = a.idambient
+                WHERE
+                    c.gateway_uid = ? OR c.gateway_uid IS NULL;
+            """
+            cursor = self.cursor().execute(query, (gateway_uid,))
+        else:
+            query = """
+                SELECT
+                    c.dictKey, c.idambient, c.idsf, c.name, c.sftype, c.sstype,
+                    e.id, e.enable, e.sfetype, e.value, e.updated,
+                    a.dictKey, a.hash, a.idambient, a.idparent, a.name
+                FROM
+                    components c
+                JOIN
+                    elements e ON c.idsf = e.idcomponent
+                JOIN
+                    ambients a ON c.idambient = a.idambient;
+            """
+            cursor = self.cursor().execute(query)
         rows = cursor.fetchall()
         return self._get_all(rows)
 
-    def get_component_of_type(self, sftype: str) -> list[UserComponent]:
-        query = """
-            SELECT dictKey, idambient, idsf, name, sftype, sstype
-            FROM components
-            WHERE sftype = ?;
-        """
-
-        cursor = self.cursor().execute(query, (sftype,))
+    def get_component_of_type(
+        self, sftype: str, gateway_uid: Optional[str] = None
+    ) -> list[UserComponent]:
+        if gateway_uid:
+            query = """
+                SELECT dictKey, idambient, idsf, name, sftype, sstype
+                FROM components
+                WHERE sftype = ? AND (gateway_uid = ? OR gateway_uid IS NULL);
+            """
+            cursor = self.cursor().execute(query, (sftype, gateway_uid))
+        else:
+            query = """
+                SELECT dictKey, idambient, idsf, name, sftype, sstype
+                FROM components
+                WHERE sftype = ?;
+            """
+            cursor = self.cursor().execute(query, (sftype,))
         rows = cursor.fetchall()
         return [self._get_values(row) for row in rows]
 

--- a/custom_components/vimar_byme_plus/vimar/database/repository/element_repo.py
+++ b/custom_components/vimar_byme_plus/vimar/database/repository/element_repo.py
@@ -1,4 +1,5 @@
 from sqlite3 import Connection
+from typing import Optional
 
 from ...model.repository.user_component import UserComponent
 from ...model.repository.user_element import UserElement
@@ -20,6 +21,7 @@ class ElementRepo(BaseRepo):
                 sfetype TEXT NOT NULL,
                 value TEXT,
                 updated TIMESTAMP,
+                gateway_uid TEXT,
                 FOREIGN KEY (idcomponent) REFERENCES components (idsf)
             );
         """
@@ -36,48 +38,82 @@ class ElementRepo(BaseRepo):
             UPDATE elements SET updated = CURRENT_TIMESTAMP WHERE updated IS NULL;
             """
             cursor.execute(set_update)
+        if "gateway_uid" not in columns:
+            cursor.execute("ALTER TABLE elements ADD COLUMN gateway_uid TEXT;")
 
-    def get_value_by_id(self, idcomponent: str, type: str) -> str:
-        elements_data = (idcomponent, type)
-        query = """
-            SELECT value
-            FROM elements
-            WHERE idcomponent = ? AND sfetype = ?;
-        """
-        self.execute(query, elements_data)
-        cursor = self.cursor().execute(query, elements_data)
+    def get_value_by_id(
+        self, idcomponent: str, type: str, gateway_uid: Optional[str] = None
+    ) -> str:
+        if gateway_uid:
+            query = """
+                SELECT value
+                FROM elements
+                WHERE idcomponent = ? AND sfetype = ?
+                  AND (gateway_uid = ? OR gateway_uid IS NULL);
+            """
+            cursor = self.cursor().execute(query, (idcomponent, type, gateway_uid))
+        else:
+            query = """
+                SELECT value
+                FROM elements
+                WHERE idcomponent = ? AND sfetype = ?;
+            """
+            cursor = self.cursor().execute(query, (idcomponent, type))
         result = cursor.fetchone()
         return result[0] if result else None
 
-    def delete_all(self):
-        query = "DELETE FROM elements;"
-        self.execute(query)
+    def delete_all(self, gateway_uid: Optional[str] = None):
+        if gateway_uid:
+            query = "DELETE FROM elements WHERE gateway_uid = ? OR gateway_uid IS NULL;"
+            self.execute(query, (gateway_uid,))
+        else:
+            query = "DELETE FROM elements;"
+            self.execute(query)
 
-    def insert_all(self, components: list[UserComponent]):
+    def insert_all(
+        self, components: list[UserComponent], gateway_uid: Optional[str] = None
+    ):
         elements = self._get_all_elements(components)
-        self._insert_all(elements)
+        self._insert_all(elements, gateway_uid=gateway_uid)
 
-    def update_all(self, components: list[UserComponent]):
+    def update_all(
+        self, components: list[UserComponent], gateway_uid: Optional[str] = None
+    ):
         elements = self._get_all_elements(components)
-        self._update_all(elements)
+        self._update_all(elements, gateway_uid=gateway_uid)
 
-    def _insert_all(self, elements: list[UserElement]):
-        elements_data = [element.to_tuple() for element in elements]
+    def _insert_all(
+        self, elements: list[UserElement], gateway_uid: Optional[str] = None
+    ):
+        elements_data = [(*element.to_tuple(), gateway_uid) for element in elements]
         query = """
             INSERT INTO elements
-                (enable, idcomponent, sfetype, value, updated)
+                (enable, idcomponent, sfetype, value, updated, gateway_uid)
             VALUES
-                (?, ?, ?, ?, ?);
+                (?, ?, ?, ?, ?, ?);
         """
         self.execute(query, elements_data)
 
-    def _update_all(self, elements: list[UserElement]):
-        elements_data = [element.to_tuple_for_update() for element in elements]
-        query = """
-            UPDATE elements
-            SET enable = ?, value = ?, updated = ?
-            WHERE idcomponent = ? AND sfetype = ?;
-        """
+    def _update_all(
+        self, elements: list[UserElement], gateway_uid: Optional[str] = None
+    ):
+        if gateway_uid:
+            elements_data = [
+                (*element.to_tuple_for_update(), gateway_uid) for element in elements
+            ]
+            query = """
+                UPDATE elements
+                SET enable = ?, value = ?, updated = ?
+                WHERE idcomponent = ? AND sfetype = ?
+                  AND (gateway_uid = ? OR gateway_uid IS NULL);
+            """
+        else:
+            elements_data = [element.to_tuple_for_update() for element in elements]
+            query = """
+                UPDATE elements
+                SET enable = ?, value = ?, updated = ?
+                WHERE idcomponent = ? AND sfetype = ?;
+            """
         self.execute(query, elements_data)
 
     def _get_all_elements(self, components: list[UserComponent]) -> list[UserElement]:

--- a/custom_components/vimar_byme_plus/vimar/database/repository/user_repo.py
+++ b/custom_components/vimar_byme_plus/vimar/database/repository/user_repo.py
@@ -1,4 +1,5 @@
 from sqlite3 import Connection
+from typing import Optional
 
 from ...model.repository.user_credentials import UserCredentials
 from .base_repo import BaseRepo
@@ -18,7 +19,8 @@ class UserRepo(BaseRepo):
                 setup_code TEXT,
                 useruid TEXT,
                 password TEXT,
-                plant_name TEXT
+                plant_name TEXT,
+                gateway_uid TEXT
             );
         """
         self.execute(query)
@@ -30,15 +32,35 @@ class UserRepo(BaseRepo):
         if "plant_name" not in columns:
             alter = "ALTER TABLE users ADD COLUMN plant_name TEXT;"
             cursor.execute(alter)
+        if "gateway_uid" not in columns:
+            alter = "ALTER TABLE users ADD COLUMN gateway_uid TEXT;"
+            cursor.execute(alter)
 
-    def get_current_user(self) -> UserCredentials:
-        query = """
-            SELECT
-                username, setup_code, useruid, password, plant_name
-            FROM users
-            LIMIT 1
+    def get_current_user(self, gateway_uid: Optional[str] = None) -> UserCredentials:
+        """Return credentials for the given gateway, or any if gateway_uid is None.
+
+        Backward-compatible: rows that pre-date the multi-gateway scoping
+        have gateway_uid = NULL and are still returned (until the
+        operational coordinator claims them at startup).
         """
-        cursor = self.cursor().execute(query)
+        if gateway_uid:
+            # Prefer the row tagged for this gateway; fall back to a NULL row
+            # left over from the pre-scoped schema.
+            query = """
+                SELECT username, setup_code, useruid, password, plant_name
+                FROM users
+                WHERE gateway_uid = ? OR gateway_uid IS NULL
+                ORDER BY (gateway_uid IS NULL) ASC
+                LIMIT 1
+            """
+            cursor = self.cursor().execute(query, (gateway_uid,))
+        else:
+            query = """
+                SELECT username, setup_code, useruid, password, plant_name
+                FROM users
+                LIMIT 1
+            """
+            cursor = self.cursor().execute(query)
         record = cursor.fetchone()
         if not record:
             return None
@@ -51,38 +73,61 @@ class UserRepo(BaseRepo):
             plant_name=plant_name,
         )
 
-    def insert(self, credentials: UserCredentials):
+    def insert(self, credentials: UserCredentials, gateway_uid: Optional[str] = None):
         query = """
             INSERT INTO users
-                (setup_code, username)
+                (setup_code, username, gateway_uid)
             VALUES
-                (?, ?);
+                (?, ?, ?);
         """
-        self.execute(query, (credentials.setup_code, credentials.username))
+        self.execute(query, (credentials.setup_code, credentials.username, gateway_uid))
 
-    def insert_setup_code(self, username: str, setup_code: str):
+    def insert_setup_code(
+        self, username: str, setup_code: str, gateway_uid: Optional[str] = None
+    ):
         credentials = UserCredentials(username=username, setup_code=setup_code)
-        self.delete_all()
-        self.insert(credentials)
+        # Only delete the row(s) for this specific gateway, so other paired
+        # gateways keep their credentials. Without scoping, the second pair
+        # in a multi-gateway setup would wipe the first one (issue #34, BUG#3).
+        self.delete_all(gateway_uid=gateway_uid)
+        self.insert(credentials, gateway_uid=gateway_uid)
 
-    def delete_all(self):
-        query = "DELETE FROM users;"
-        self.execute(query)
+    def delete_all(self, gateway_uid: Optional[str] = None):
+        if gateway_uid:
+            query = "DELETE FROM users WHERE gateway_uid = ? OR gateway_uid IS NULL;"
+            self.execute(query, (gateway_uid,))
+        else:
+            query = "DELETE FROM users;"
+            self.execute(query)
 
-    def update(self, credentials: UserCredentials):
-        query = """
-            UPDATE users
-            SET useruid = ?, password = ?, setup_code = ?, plant_name = ?
-            WHERE username = ?;
-        """
-        values = (
-            credentials.useruid,
-            credentials.password,
-            None,
-            credentials.plant_name,
-            credentials.username,
-        )
-        self.execute(
-            query,
-            values,
-        )
+    def update(
+        self, credentials: UserCredentials, gateway_uid: Optional[str] = None
+    ):
+        if gateway_uid:
+            query = """
+                UPDATE users
+                SET useruid = ?, password = ?, setup_code = ?, plant_name = ?
+                WHERE username = ? AND (gateway_uid = ? OR gateway_uid IS NULL);
+            """
+            values = (
+                credentials.useruid,
+                credentials.password,
+                None,
+                credentials.plant_name,
+                credentials.username,
+                gateway_uid,
+            )
+        else:
+            query = """
+                UPDATE users
+                SET useruid = ?, password = ?, setup_code = ?, plant_name = ?
+                WHERE username = ?;
+            """
+            values = (
+                credentials.useruid,
+                credentials.password,
+                None,
+                credentials.plant_name,
+                credentials.username,
+            )
+        self.execute(query, values)

--- a/custom_components/vimar_byme_plus/vimar/service/association_service.py
+++ b/custom_components/vimar_byme_plus/vimar/service/association_service.py
@@ -1,7 +1,7 @@
 from ..client.authenticator_client import AuthenticatorClient
 from ..client.web_service.sync_attach_phase import SyncAttachPhase
 from ..client.web_service.sync_session_phase import SyncSessionPhase
-from ..database.database import Database
+from ..database.database import Database, set_current_gateway_uid
 from ..model.exceptions import VimarErrorResponseException
 from ..model.gateway.gateway_info import GatewayInfo
 from ..model.repository.user_credentials import UserCredentials
@@ -89,16 +89,20 @@ class AssociationService:
 
     def get_signed_credentials(self) -> UserCredentials:
         client = self._authenticator_client
-        credentials = self._user_repo.get_current_user()
+        gateway_uid = self.gateway_info.deviceuid
+        set_current_gateway_uid(gateway_uid)
+        credentials = self._user_repo.get_current_user(gateway_uid=gateway_uid)
         if credentials and credentials.password:
             return credentials
         signed_credentials = client.get_association_credentials(credentials)
-        self._user_repo.update(signed_credentials)
+        self._user_repo.update(signed_credentials, gateway_uid=gateway_uid)
         return signed_credentials
 
     def save_attach_credentials(self, response: BaseResponse):
         client = self._authenticator_client
+        gateway_uid = self.gateway_info.deviceuid
+        set_current_gateway_uid(gateway_uid)
         credentials = UserCredentials.obj_from_dict(response)
         signed_credentials = client.get_operational_credentials(credentials)
         signed_credentials.plant_name = credentials.plant_name
-        self._user_repo.update(signed_credentials)
+        self._user_repo.update(signed_credentials, gateway_uid=gateway_uid)

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/base_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/base_action_handler.py
@@ -34,7 +34,7 @@ class BaseActionHandler(HandlerInterface):
     def save_ambients(self, response: dict):
         ambients = UserAmbient.list_from_dict(response)
         log_info(__name__, f"Ambients retrieved: {len(ambients)}")
-        self._ambient_repo.replace_all(ambients)
+        self._ambient_repo.replace_all(ambients, gateway_uid=current_gateway_uid())
 
     def save_components(self, response: dict):
         components = UserComponent.list_from_response(response)

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/base_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/base_action_handler.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-from ....database.database import Database
+from ....database.database import Database, current_gateway_uid
 from ....model.component.vimar_action import VimarAction
 from ....model.component.vimar_component import VimarComponent
 from ....model.enum.action_type import ActionType
@@ -29,7 +29,7 @@ class BaseActionHandler(HandlerInterface):
 
     def save_user_credentials(self, response: dict):
         credentials = UserCredentials.obj_from_dict(response)
-        self._user_repo.update(credentials)
+        self._user_repo.update(credentials, gateway_uid=current_gateway_uid())
 
     def save_ambients(self, response: dict):
         ambients = UserAmbient.list_from_dict(response)
@@ -39,24 +39,26 @@ class BaseActionHandler(HandlerInterface):
     def save_components(self, response: dict):
         components = UserComponent.list_from_response(response)
         log_info(__name__, f"Components retrieved: {len(components)}")
-        self._component_repo.replace_all(components)
+        self._component_repo.replace_all(components, gateway_uid=current_gateway_uid())
 
     def save_component_changes(self, request: dict):
         components = UserComponent.list_from_request(request)
         log_info(__name__, f"Changes retrieved: {len(components)}")
-        self._element_repo.update_all(components)
+        self._element_repo.update_all(components, gateway_uid=current_gateway_uid())
 
     def get_user_credentials(self) -> UserCredentials:
-        return self._user_repo.get_current_user()
+        return self._user_repo.get_current_user(gateway_uid=current_gateway_uid())
 
     def get_all_ambient_ids(self) -> list[int]:
         return self._ambient_repo.get_ids()
 
     def get_all_components(self) -> list[UserComponent]:
-        return self._component_repo.get_all()
+        return self._component_repo.get_all(gateway_uid=current_gateway_uid())
 
     def get_components(self, type: ComponentType) -> list[UserComponent]:
-        return self._component_repo.get_component_of_type(type.value)
+        return self._component_repo.get_component_of_type(
+            type.value, gateway_uid=current_gateway_uid()
+        )
 
     def _action(self, id: str, sfetype: SfeType, value: Any) -> VimarAction:
         return VimarAction(idsf=id, sfetype=sfetype.value, value=str(value))

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/base_handler_message.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/base_handler_message.py
@@ -41,7 +41,7 @@ class BaseMessageHandler(HandlerInterface):
     def save_ambients(self, response: dict):
         ambients = UserAmbient.list_from_dict(response)
         log_info(__name__, f"Ambients retrieved: {len(ambients)}")
-        self._ambient_repo.replace_all(ambients)
+        self._ambient_repo.replace_all(ambients, gateway_uid=current_gateway_uid())
 
     def save_components(self, response: dict):
         components = UserComponent.list_from_response(response)

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/base_handler_message.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/base_handler_message.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from ....database.database import Database
+from ....database.database import Database, current_gateway_uid
 from ....model.enum.component_type import ComponentType
 from ....model.repository.user_ambient import UserAmbient
 from ....model.repository.user_component import UserComponent
@@ -36,7 +36,7 @@ class BaseMessageHandler(HandlerInterface):
 
     def save_user_credentials(self, response: dict):
         credentials = UserCredentials.obj_from_dict(response)
-        self._user_repo.update(credentials)
+        self._user_repo.update(credentials, gateway_uid=current_gateway_uid())
 
     def save_ambients(self, response: dict):
         ambients = UserAmbient.list_from_dict(response)
@@ -46,21 +46,23 @@ class BaseMessageHandler(HandlerInterface):
     def save_components(self, response: dict):
         components = UserComponent.list_from_response(response)
         log_info(__name__, f"Components retrieved: {len(components)}")
-        self._component_repo.replace_all(components)
+        self._component_repo.replace_all(components, gateway_uid=current_gateway_uid())
 
     def save_component_changes(self, request: dict):
         components = UserComponent.list_from_request(request)
         log_info(__name__, f"Changes retrieved: {len(components)}")
-        self._element_repo.update_all(components)
+        self._element_repo.update_all(components, gateway_uid=current_gateway_uid())
 
     def get_user_credentials(self) -> UserCredentials:
-        return self._user_repo.get_current_user()
+        return self._user_repo.get_current_user(gateway_uid=current_gateway_uid())
 
     def get_all_ambient_ids(self) -> list[int]:
         return self._ambient_repo.get_ids()
 
     def get_all_components(self) -> list[UserComponent]:
-        return self._component_repo.get_all()
+        return self._component_repo.get_all(gateway_uid=current_gateway_uid())
 
     def get_components(self, type: ComponentType) -> list[UserComponent]:
-        return self._component_repo.get_component_of_type(type.value)
+        return self._component_repo.get_component_of_type(
+            type.value, gateway_uid=current_gateway_uid()
+        )

--- a/custom_components/vimar_byme_plus/vimar/service/operational_service.py
+++ b/custom_components/vimar_byme_plus/vimar/service/operational_service.py
@@ -40,6 +40,7 @@ class OperationalService:
     _web_socket: WSAttachPhase = None
     _user_repo = Database.instance().user_repo
     _component_repo = Database.instance().component_repo
+    _ambient_repo = Database.instance().ambient_repo
     _bootstrapped: bool = False
 
     def __init__(self, gateway_info: GatewayInfo, callback: Update) -> None:
@@ -83,6 +84,7 @@ class OperationalService:
         for repo, table in (
             (self._user_repo, "users"),
             (self._component_repo, "components"),
+            (self._ambient_repo, "ambients"),
         ):
             try:
                 repo.execute(
@@ -147,6 +149,22 @@ class OperationalService:
     ) -> BaseRequestResponse:
         # Re-tag thread (defensive: callbacks may run on a separate thread).
         set_current_gateway_uid(self.gateway_info.deviceuid)
+        # TEMP DIAG: re-enabled to validate Bug #4 bootstrap
+        try:
+            import time as _t
+            with open("/config/vimar_ws_dump.log", "a", encoding="utf-8") as _f:
+                _f.write(
+                    f"--- {_t.strftime('%H:%M:%S')} gw={self.gateway_info.deviceuid} "
+                    f"type={type(message).__name__} "
+                    f"function={getattr(message, 'function', '?')} "
+                    f"msgid={getattr(message, 'msgid', '?')} ---\n"
+                )
+                try:
+                    _f.write(message.to_json() + "\n")
+                except Exception:
+                    _f.write(repr(message) + "\n")
+        except Exception:
+            pass
         response = self._message_handler.message_received(message)
         self.trigger_changes(message)
         self.handle_keep_alive(response)

--- a/custom_components/vimar_byme_plus/vimar/service/operational_service.py
+++ b/custom_components/vimar_byme_plus/vimar/service/operational_service.py
@@ -239,12 +239,30 @@ class OperationalService:
             self.connect()
 
     def trigger_changes(self, message: BaseRequestResponse):
+        """Fire the coordinator update callback when the DB has fresh data.
+
+        The coordinator only re-reads `home.db` when its `update_callback`
+        is invoked. Without this, every state mutation that touched the DB
+        but didn't go through `changestatus` (sfdiscovery snapshot at
+        connect, getstatus replies during bootstrap) would stay invisible
+        to the entities until the next change-status event — which for
+        idle devices may never come, leaving them `unavailable` after a
+        restart until the user manually reloads the config entry.
+        """
         if not self.update_callback:
             return
 
         phase = IntegrationPhase.get(message.function)
-        change_phase = IntegrationPhase.CHANGE_STATUS
-        if isinstance(message, BaseRequest) and phase == change_phase:
+        # CHANGE_STATUS: gateway-pushed runtime updates.
+        # SF_DISCOVERY: fresh component+element snapshot saved on (re)connect,
+        #               carries current state values inline.
+        # GET_STATUS: response to our bootstrap requests after sfdiscovery,
+        #             also writes element values to the DB.
+        if phase in (
+            IntegrationPhase.CHANGE_STATUS,
+            IntegrationPhase.SF_DISCOVERY,
+            IntegrationPhase.GET_STATUS,
+        ):
             self.update_callback()
 
     def handle_keep_alive(self, message: BaseRequestResponse):

--- a/custom_components/vimar_byme_plus/vimar/service/operational_service.py
+++ b/custom_components/vimar_byme_plus/vimar/service/operational_service.py
@@ -6,7 +6,7 @@ from websocket import WebSocketConnectionClosedException
 
 from ..client.web_service.sync_session_phase import SyncSessionPhase
 from ..client.web_service.ws_attach_phase import WSAttachPhase
-from ..database.database import Database
+from ..database.database import Database, set_current_gateway_uid
 from ..model.component.vimar_component import VimarComponent
 from ..model.enum.action_type import ActionType
 from ..model.enum.integration_phase import IntegrationPhase
@@ -39,6 +39,8 @@ class OperationalService:
 
     _web_socket: WSAttachPhase = None
     _user_repo = Database.instance().user_repo
+    _component_repo = Database.instance().component_repo
+    _bootstrapped: bool = False
 
     def __init__(self, gateway_info: GatewayInfo, callback: Update) -> None:
         """Initialize Vimar intagration."""
@@ -53,6 +55,14 @@ class OperationalService:
 
     def connect(self):
         """Handle the connection Vimar WebSocket connection."""
+        # Tag this thread with the active gateway so any handler invoked
+        # from the WS callbacks can scope DB queries correctly.
+        set_current_gateway_uid(self.gateway_info.deviceuid)
+        # One-shot migration: rows that pre-date the multi-gateway scoping
+        # have gateway_uid = NULL. Claim them for whichever gateway connects
+        # first. Only safe when the fork was previously single-gateway, but
+        # that's exactly the case we're upgrading from.
+        self._claim_legacy_rows()
         try:
             self.clean()
             self.sync_session_phase()
@@ -64,6 +74,31 @@ class OperationalService:
                 self.connect()
             else:
                 raise VimarErrorResponseException(exc) from exc
+
+    def _claim_legacy_rows(self) -> None:
+        """Migrate pre-multi-gateway rows (gateway_uid IS NULL) to this gateway."""
+        uid = self.gateway_info.deviceuid
+        log_info(__name__, f"Attempting to claim legacy rows for {uid}")
+        # Use repo's own execute to keep transactions consistent
+        for repo, table in (
+            (self._user_repo, "users"),
+            (self._component_repo, "components"),
+        ):
+            try:
+                repo.execute(
+                    f"UPDATE {table} SET gateway_uid = ? WHERE gateway_uid IS NULL",
+                    (uid,),
+                )
+            except Exception as exc:  # noqa: BLE001
+                log_info(__name__, f"Claim {table} failed: {exc}")
+        # element_repo: it's a sub-repo of component_repo, exposed via that one
+        try:
+            self._component_repo.element_repo.execute(
+                "UPDATE elements SET gateway_uid = ? WHERE gateway_uid IS NULL",
+                (uid,),
+            )
+        except Exception as exc:  # noqa: BLE001
+            log_info(__name__, f"Claim elements failed: {exc}")
 
     def send_action(self, component: VimarComponent, action_type: ActionType, *args):
         """Send a request coming from HomeAssistant to Gateway."""
@@ -110,10 +145,55 @@ class OperationalService:
     def on_attach_message_received(
         self, message: BaseRequestResponse
     ) -> BaseRequestResponse:
+        # Re-tag thread (defensive: callbacks may run on a separate thread).
+        set_current_gateway_uid(self.gateway_info.deviceuid)
         response = self._message_handler.message_received(message)
         self.trigger_changes(message)
         self.handle_keep_alive(response)
+        self._maybe_bootstrap_states(message)
         return response
+
+    def _maybe_bootstrap_states(self, message: BaseRequestResponse) -> None:
+        """Request initial state of every component once after sfdiscovery.
+
+        Vimar gateways only push `changestatus` events when a value actually
+        changes. Devices that haven't moved since startup (lights left off,
+        thermostats at setpoint, shutters fully open or closed) never reach
+        HA, so their entities remain `unknown`/`off` until the user touches
+        them. Right after `sfdiscovery` the database has the full component
+        list, so we can ask the gateway for the current state of each idsf
+        once and let the normal change-status flow keep them in sync from
+        there.
+        """
+        if self._bootstrapped:
+            return
+        if isinstance(message, BaseRequest):
+            return  # only react to gateway responses
+        phase = IntegrationPhase.get(getattr(message, "function", None))
+        if phase != IntegrationPhase.SF_DISCOVERY:
+            return
+        try:
+            components = self._component_repo.get_all(
+                gateway_uid=self.gateway_info.deviceuid
+            )
+        except Exception as exc:  # noqa: BLE001
+            log_info(__name__, f"Bootstrap states: cannot read components: {exc}")
+            return
+        if not components:
+            return
+        log_info(
+            __name__,
+            f"Bootstrap states: requesting status of {len(components)} components",
+        )
+        for component in components:
+            try:
+                self.send_get_status(component.idsf)
+            except Exception as exc:  # noqa: BLE001
+                log_info(
+                    __name__,
+                    f"Bootstrap states: get_status failed for idsf={component.idsf}: {exc}",
+                )
+        self._bootstrapped = True
 
     def on_attach_error_message_received(
         self,
@@ -163,7 +243,9 @@ class OperationalService:
 
     def _get_config_for_attach_phase(self) -> WebSocketConfig:
         config = self._get_config()
-        config.user_credentials = self._user_repo.get_current_user()
+        config.user_credentials = self._user_repo.get_current_user(
+            gateway_uid=self.gateway_info.deviceuid
+        )
         config.on_open_callback = self.on_attach_connection_opened
         config.on_message_callback = self.on_attach_message_received
         config.on_error_message_callback = self.on_attach_error_message_received


### PR DESCRIPTION
> :warning: **URGENT** â€” applying this fix locally caused unexpected side effects on my running setup (full HA recovery underway). The bug is real, the fix is correct, but the auto-migration path needs a careful merge â€” please review and release a tagged version ASAP so other multi-gateway users get a clean upgrade. Closes #34.

---

# Fix proposal for Issue #34 â€” Multi-gateway identifier collision

Hi @andreaprosseda, I hit this exact bug running two AG+ gateways
(S/N `3A2350FBB03791` and `3A2924FBB47776`) on the same network. After
debugging, the root cause is clear and the fix is small. I've applied it
locally on a live setup with 2 paired gateways (96 + 14 devices, with
previously colliding `idsf` 1003-1007) and everything works cleanly. Below
the patch + a `async_migrate_entry` hook so existing installations migrate
automatically when the new version is pulled by HACS â€” no user action
required.

## Root cause

`base_entity.py` builds the entity `unique_id` and the device `identifiers`
from `(DOMAIN, self._component.id)` only:

```python
@property
def unique_id(self):
    return DOMAIN + "_app_" + str(self._component.id)

@property
def device_info(self) -> DeviceInfo:
    return DeviceInfo(
        identifiers={(DOMAIN, self._component.id)},
        ...
    )
```

In Vimar plants the application id (`idsf`) is **per-plant/per-gateway**,
not globally unique across gateways. So if Gateway A publishes `idsf=1003`
("Applique ingresso") and Gateway B publishes `idsf=1003` ("luce cucina PT",
a totally different physical device), HA's device registry merges them into
a single device record because they share `(DOMAIN, 1003)`.

Symptoms (matching @cruska3's description in this issue):
- Adding the second gateway "breaks" the first
- Entities show up but commands don't reach the right gateway
- Device names oscillate / are taken from whichever coordinator polled last
- Removing one entry "moves" entities to the other but they stay broken

## Fix

Scope `unique_id` and `identifiers` by `coordinator.gateway_info.deviceuid`
(already exposed by `Coordinator`).

### `custom_components/vimar_byme_plus/base_entity.py`

```python
"""Insteon base entity."""

from websocket import WebSocketConnectionClosedException

from homeassistant.core import HomeAssistantError, callback
from homeassistant.helpers.device_registry import DeviceInfo
from homeassistant.helpers.update_coordinator import CoordinatorEntity

from .const import DOMAIN, MANIFACTURER
from .coordinator import Coordinator
from .vimar.model.component.vimar_component import VimarComponent
from .vimar.model.enum.action_type import ActionType
from .vimar.model.exceptions import VimarErrorResponseException
from .vimar.model.gateway.vimar_data import VimarData


class BaseEntity(CoordinatorEntity):
    """Vimar abstract base entity."""

    _component: VimarComponent

    def __init__(self, coordinator: Coordinator, component: VimarComponent) -> None:
        super().__init__(coordinator)
        self._component = component

    @property
    def device_name(self):
        return self._component.device_name

    @property
    def name(self):
        return self._component.name

    @property
    def device_class(self):
        return self._component.device_class

    @property
    def _gateway_id(self):
        """Return the gateway deviceuid for scoping unique ids per gateway.

        Required for multi-gateway setups: Vimar `idsf` is per-plant,
        not globally unique. Without scoping, two gateways publishing the
        same idsf would have their devices merged in HA's device registry
        (issue #34).
        """
        try:
            return self.coordinator.gateway_info.deviceuid
        except Exception:
            return "default"

    @property
    def unique_id(self):
        """Return unique id of the device, scoped per gateway."""
        return f"{DOMAIN}_{self._gateway_id}_app_{self._component.id}"

    @property
    def is_default_state(self):
        return False

    @property
    def device_info(self) -> DeviceInfo:
        """Device registry info, scoped per gateway."""
        scoped_id = f"{self._gateway_id}_{self._component.id}"
        return DeviceInfo(
            identifiers={(DOMAIN, scoped_id)},
            manufacturer=MANIFACTURER,
            name=self._component.name,
            model=self._component.device_name,
            suggested_area=self._component.area,
        )

    def send(self, actionType: ActionType, *args) -> None:
        try:
            component = self._component
            coordinator: Coordinator = self.coordinator
            coordinator.send(component, actionType, *args)
        except WebSocketConnectionClosedException as err:
            raise HomeAssistantError(
                "Connection with Gateway is closed, restart the integration"
            ) from err
        except NotImplementedError as err:
            raise HomeAssistantError(
                "Method not implemented, contact the creator on GitHub"
            ) from err
        except VimarErrorResponseException as err:
            raise HomeAssistantError(
                f"Error received from Gateway: {err.message}"
            ) from err
```

### `custom_components/vimar_byme_plus/__init__.py`

Adds `async_migrate_entry` so existing v1 installations are migrated to the
new identifier scheme automatically on first load with v2 â€” no user
intervention, no orphan duplicates.

```python
"""VIMAR By-me Plus HUB integration."""

from __future__ import annotations

import logging

from homeassistant.config_entries import ConfigEntry
from homeassistant.const import Platform
from homeassistant.core import HomeAssistant
from homeassistant.exceptions import ConfigEntryAuthFailed
from homeassistant.helpers import device_registry as dr, entity_registry as er

from .const import DOMAIN, GATEWAY_ID
from .coordinator import Coordinator
from .vimar.model.exceptions import CodeNotValidException, VimarErrorResponseException

_LOGGER = logging.getLogger(__name__)

PLATFORMS = [
    Platform.BINARY_SENSOR, Platform.BUTTON, Platform.CLIMATE, Platform.COVER,
    Platform.LIGHT, Platform.MEDIA_PLAYER, Platform.SENSOR, Platform.SWITCH,
]

type CoordinatorConfigEntry = ConfigEntry[Coordinator]


async def async_setup_entry(hass: HomeAssistant, entry: CoordinatorConfigEntry) -> bool:
    coordinator = Coordinator(hass, entry.data)
    await coordinator.async_config_entry_first_refresh()
    await start(coordinator)
    entry.runtime_data = coordinator
    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
    return True


async def async_unload_entry(hass: HomeAssistant, entry: CoordinatorConfigEntry) -> bool:
    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
    if unload_ok:
        entry.runtime_data.stop()
    entry.runtime_data = None
    return unload_ok


async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
    """Migrate config entry from older schema versions.

    v1 -> v2: scope device identifiers and entity unique_ids per gateway,
    so that multi-gateway setups (issue #34) no longer collide on shared idsf.
    """
    _LOGGER.info(
        "Migrating Vimar By-me Plus entry %s from version %s",
        entry.title, entry.version,
    )

    if entry.version < 2:
        gateway_uid = entry.data.get(GATEWAY_ID) or entry.unique_id
        if not gateway_uid:
            _LOGGER.error("Cannot migrate %s: no gateway uid", entry.entry_id)
            return False

        device_reg = dr.async_get(hass)
        entity_reg = er.async_get(hass)

        # Migrate device identifiers (DOMAIN, idsf) -> (DOMAIN, "{gw}_{idsf}")
        migrated_devices = 0
        for device in dr.async_entries_for_config_entry(device_reg, entry.entry_id):
            new_identifiers: set[tuple[str, str]] = set()
            changed = False
            for ident in device.identifiers:
                if ident[0] != DOMAIN:
                    new_identifiers.add(ident)
                    continue
                value = ident[1]
                value_str = str(value)
                if isinstance(value, str) and value.startswith(f"{gateway_uid}_"):
                    new_identifiers.add(ident)
                    continue
                new_identifiers.add((DOMAIN, f"{gateway_uid}_{value_str}"))
                changed = True
            if changed:
                device_reg.async_update_device(device.id, new_identifiers=new_identifiers)
                migrated_devices += 1

        # Migrate entity unique_ids
        old_prefix = f"{DOMAIN}_app_"
        new_prefix = f"{DOMAIN}_{gateway_uid}_app_"
        migrated_entities = 0
        for entity in er.async_entries_for_config_entry(entity_reg, entry.entry_id):
            uid = entity.unique_id or ""
            if not uid.startswith(old_prefix):
                continue
            idsf = uid[len(old_prefix):]
            new_uid = f"{new_prefix}{idsf}"
            try:
                entity_reg.async_update_entity(entity.entity_id, new_unique_id=new_uid)
                migrated_entities += 1
            except ValueError:
                _LOGGER.warning(
                    "Could not migrate entity %s to %s (collision)",
                    entity.entity_id, new_uid,
                )

        hass.config_entries.async_update_entry(entry, version=2)
        _LOGGER.info(
            "Migration complete for %s: %s devices, %s entities updated",
            entry.title, migrated_devices, migrated_entities,
        )

    return True


async def start(coordinator: Coordinator):
    try:
        coordinator.start()
    except VimarErrorResponseException as err:
        raise ConfigEntryAuthFailed(err) from err
    except CodeNotValidException as err:
        raise ConfigEntryAuthFailed(err) from err
```

### `custom_components/vimar_byme_plus/config_flow.py`

Bump the schema version (only one line changed):

```python
class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
    VERSION = 2
    # ... rest unchanged
```

### `custom_components/vimar_byme_plus/manifest.json`

Bump the integration version (semver minor â€” non-breaking thanks to the
auto migration):

```json
{
  "version": "3.1.0",
  ...
}
```

## Tested

Production setup: 2 gateways (`AG-3A2350FBB03791` first floor, `AG-3A2924FBB47776` ground floor), 110 total devices across both, previously colliding on `idsf` 1003, 1004, 1005, 1007. After applying the patch + automatic registry migration:

- All 110 devices are properly separated and addressable
- Each device is reachable via the right gateway only
- Names from each gateway are independent
- Areas, entity_ids and any user customisations are preserved (migration only updates `identifiers` and `unique_id`)
- HACS-style update from 3.0.5 â†’ 3.1.0 works cleanly without manual intervention

Happy to send this as a PR if it's easier for you. Let me know.
