### PR TITLE
Multi-gateway support: 4 fixes (closes #34)

### DIFF
--- a/custom_components/vimar_byme_plus/__init__.py
+++ b/custom_components/vimar_byme_plus/__init__.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
+from .const import DOMAIN, GATEWAY_ID
 from .coordinator import Coordinator
 from .vimar.model.exceptions import CodeNotValidException, VimarErrorResponseException
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -43,6 +49,75 @@ async def async_unload_entry(
         entry.runtime_data.stop()
     entry.runtime_data = None
     return unload_ok
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate config entry to v2: scope every entity's unique_id by gateway_uid.
+
+    Strategy chosen deliberately MINIMAL after two earlier attempts (v2.54
+    and v2.56 in the project changelog) that broke user-renamed entity_ids:
+
+    * Only `unique_id` is touched here. `entity_id`, friendly name, area,
+      device_id, icon, anything else the user may have customised is left
+      exactly as-is.
+    * Idempotent: an entity whose `unique_id` already starts with
+      `vimar_byme_plus_<gw_uid>_` is skipped.
+    * Defensive: a `ValueError` from the registry (collision because some
+      previous attempt left a partially scoped duplicate behind) is logged
+      and the loop keeps going. Worst case for that entity: it stays on
+      the legacy unscoped `unique_id` and the user can clean it up by
+      deleting it from the UI; nothing else breaks.
+
+    Why we need it: `base_entity.unique_id` now includes the gateway uid,
+    so freshly-created entities at boot get
+    `vimar_byme_plus_<gw_uid>_app_<idsf>`. Without this migration, the
+    pre-existing entities would keep their legacy `vimar_byme_plus_app_<idsf>`
+    and become orphan unavailable instances after the next start.
+    """
+    if entry.version >= 3:
+        return True
+
+    gateway_uid = entry.data.get(GATEWAY_ID)
+    if not gateway_uid:
+        _LOGGER.warning(
+            "Migration: entry %s has no GATEWAY_ID, skipping unique_id rescoping",
+            entry.entry_id,
+        )
+        hass.config_entries.async_update_entry(entry, version=3)
+        return True
+
+    legacy_prefix = f"{DOMAIN}_app_"
+    new_prefix = f"{DOMAIN}_{gateway_uid}_app_"
+
+    registry = er.async_get(hass)
+    entities = er.async_entries_for_config_entry(registry, entry.entry_id)
+
+    migrated = 0
+    skipped = 0
+    failed = 0
+    for ent in entities:
+        uid = ent.unique_id
+        if not uid.startswith(legacy_prefix):
+            skipped += 1
+            continue
+        new_uid = new_prefix + uid[len(legacy_prefix):]
+        try:
+            registry.async_update_entity(ent.entity_id, new_unique_id=new_uid)
+            migrated += 1
+        except ValueError as err:
+            _LOGGER.warning(
+                "Migration: cannot rescope %s (%s -> %s): %s",
+                ent.entity_id, uid, new_uid, err,
+            )
+            failed += 1
+
+    _LOGGER.info(
+        "Migration entry %s (gateway %s): rescoped %d, already-ok %d, failed %d",
+        entry.entry_id, gateway_uid, migrated, skipped, failed,
+    )
+
+    hass.config_entries.async_update_entry(entry, version=3)
+    return True
 
 
 async def start(coordinator: Coordinator):

--- a/custom_components/vimar_byme_plus/base_entity.py
+++ b/custom_components/vimar_byme_plus/base_entity.py
@@ -44,8 +44,20 @@ class BaseEntity(CoordinatorEntity):
 
     @property
     def unique_id(self):
-        """Return unique id of the device."""
-        return DOMAIN + "_app_" + str(self._component.id)
+        """Return unique id of the device, scoped per gateway.
+
+        Without the gateway_uid in the unique_id, two paired By-me Plus
+        gateways that happen to share an `idsf` (very common: idsf 1003
+        is "Applique ingresso" on Casa Trenno but "luce cucina" on
+        TrennoPT) collide in the HA entity registry and only the first
+        survives. Including the gateway uid makes them distinct.
+        """
+        gw_uid = getattr(self.coordinator, "gateway_info", None)
+        if gw_uid is not None:
+            gw_uid = getattr(gw_uid, "deviceuid", None)
+        if gw_uid:
+            return f"{DOMAIN}_{gw_uid}_app_{self._component.id}"
+        return f"{DOMAIN}_app_{self._component.id}"
 
     @property
     def is_default_state(self):
@@ -54,13 +66,18 @@ class BaseEntity(CoordinatorEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        """Return device registry information for this entity."""
+        """Return device registry information for this entity.
+
+        `suggested_area` removed: the upstream `component.area` is the raw
+        ambient name from the Vimar DB, which doesn't always match an
+        existing HA area_id. When it doesn't, HA *creates* a brand new
+        area on every (re)start. Areas are managed by the user via the UI.
+        """
         return DeviceInfo(
             identifiers={(DOMAIN, self._component.id)},
             manufacturer=MANIFACTURER,
             name=self._component.name,
             model=self._component.device_name,
-            suggested_area=self._component.area,
         )
 
     def send(self, actionType: ActionType, *args) -> None:

--- a/custom_components/vimar_byme_plus/config_flow.py
+++ b/custom_components/vimar_byme_plus/config_flow.py
@@ -43,7 +43,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     discovery_info: zeroconf.ZeroconfServiceInfo = None
 
-    VERSION = 1
+    VERSION = 3
 
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 

--- a/custom_components/vimar_byme_plus/light.py
+++ b/custom_components/vimar_byme_plus/light.py
@@ -45,7 +45,18 @@ class Light(BaseEntity, LightEntity):
     HA_COLOR_TEMP_SCALE = (2700, 6500)
     _attr_min_color_temp_kelvin = 2700
     _attr_max_color_temp_kelvin = 6500
+    # Drop the legacy stringa `device_class="light"` that the upstream mapper
+    # injects via VimarLight: it isn't a valid `LightDeviceClass` value, and
+    # the new HA tile card renders such entities as a blank circle instead of
+    # the default lightbulb icon. Returning None makes HA fall back to the
+    # built-in `mdi:lightbulb` / `mdi:lightbulb-off` based on state.
+    _attr_device_class = None
     _component: VimarLight
+
+    @property
+    def device_class(self) -> None:
+        """Override BaseEntity.device_class for lights — see _attr_device_class above."""
+        return None
 
     def __init__(self, coordinator: Coordinator, component: VimarLight) -> None:
         """Initialize the light."""

--- a/custom_components/vimar_byme_plus/manifest.json
+++ b/custom_components/vimar_byme_plus/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/andreaprosseda/vimar-byme-plus-homeassistant/issues",
   "requirements": ["websocket-client"],
-  "version": "3.0.7",
+  "version": "3.0.8",
   "zeroconf": ["_vimar-devctrl._tcp.local."]
 }

--- a/custom_components/vimar_byme_plus/manifest.json
+++ b/custom_components/vimar_byme_plus/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/andreaprosseda/vimar-byme-plus-homeassistant/issues",
   "requirements": ["websocket-client"],
-  "version": "3.0.6",
+  "version": "3.0.7",
   "zeroconf": ["_vimar-devctrl._tcp.local."]
 }

--- a/custom_components/vimar_byme_plus/manifest.json
+++ b/custom_components/vimar_byme_plus/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/andreaprosseda/vimar-byme-plus-homeassistant/issues",
   "requirements": ["websocket-client"],
-  "version": "3.0.5",
+  "version": "3.0.6",
   "zeroconf": ["_vimar-devctrl._tcp.local."]
 }

--- a/custom_components/vimar_byme_plus/vimar/client/vimar_client.py
+++ b/custom_components/vimar_byme_plus/vimar/client/vimar_client.py
@@ -62,7 +62,8 @@ class VimarClient:
 
     def retrieve_data(self) -> VimarData:
         """Get the latest data from DB."""
-        components = self._component_repo.get_all()
+        gateway_uid = self._operational_service.gateway_info.deviceuid
+        components = self._component_repo.get_all(gateway_uid=gateway_uid)
         return VimarDataMapper.from_list(components)
 
     def get_gateway_info(self) -> GatewayInfo:
@@ -72,14 +73,18 @@ class VimarClient:
         return self._operational_service.gateway_info is not None
 
     def has_credentials(self) -> bool:
-        credentials = self._user_repo.get_current_user()
+        gateway_uid = self._operational_service.gateway_info.deviceuid
+        credentials = self._user_repo.get_current_user(gateway_uid=gateway_uid)
         return credentials and credentials.password is not None
 
     def set_setup_code(self, setup_code: str):
         if not setup_code:
             return
         self.validate_code(setup_code)
-        self._user_repo.insert_setup_code(USERNAME, setup_code)
+        gateway_uid = self._operational_service.gateway_info.deviceuid
+        self._user_repo.insert_setup_code(
+            USERNAME, setup_code, gateway_uid=gateway_uid
+        )
 
     def same_code(self, setup_code: str, current_user: UserCredentials) -> bool:
         if not current_user:

--- a/custom_components/vimar_byme_plus/vimar/database/database.py
+++ b/custom_components/vimar_byme_plus/vimar/database/database.py
@@ -1,3 +1,4 @@
+import os
 import sqlite3
 from sqlite3 import Connection, Error
 from typing import Optional
@@ -37,10 +38,31 @@ class Database:
         self.ambient_repo = AmbientRepo(conn)
         self.user_repo = UserRepo(conn)
         self.component_repo = ComponentRepo(conn, self.element_repo)
+        # Defensive: explicitly commit the CREATE TABLE statements run by each
+        # repo's __init__. Without this, an exception later in setup may leave
+        # the SQLite file as 0 bytes (no schema flushed to disk), and every
+        # subsequent reconnect re-opens an empty file. See discussion in #34.
+        try:
+            conn.commit()
+        except Error as e:
+            log_error(__name__, f"Could not commit schema: {e}")
 
     def create_connection(self) -> Connection:
         try:
             file_path = get_file_path(DATABASE_NAME)
+            # Self-heal: if a previous failed init left a 0-byte file,
+            # remove it so SQLite can write a fresh schema. Otherwise we
+            # would keep reopening the empty file forever and the integration
+            # would never reach the operational phase.
+            try:
+                if os.path.exists(file_path) and os.path.getsize(file_path) == 0:
+                    os.remove(file_path)
+                    log_info(
+                        __name__,
+                        f"Removed empty {DATABASE_NAME} left by a previous failed init",
+                    )
+            except OSError as e:
+                log_error(__name__, f"Could not remove empty db file: {e}")
             self._connection = sqlite3.connect(file_path, check_same_thread=False)
             log_info(__name__, "Connection to SQLite DB successful")
             return self._connection

--- a/custom_components/vimar_byme_plus/vimar/database/database.py
+++ b/custom_components/vimar_byme_plus/vimar/database/database.py
@@ -1,5 +1,6 @@
 import os
 import sqlite3
+import threading
 from sqlite3 import Connection, Error
 from typing import Optional
 
@@ -11,6 +12,24 @@ from .repository.element_repo import ElementRepo
 from .repository.user_repo import UserRepo
 
 DATABASE_NAME = "home.db"
+
+# Thread-local gateway scope. Each coordinator runs in its own thread; the
+# coordinator sets its gateway uid here on connect so repos and message
+# handlers can filter rows belonging to *this* gateway without every method
+# having to forward an extra argument. Without scoping, the second gateway's
+# pair wipes the first one's users/components/elements rows from the shared
+# singleton DB (issue #34, Bug #3).
+_thread_local = threading.local()
+
+
+def set_current_gateway_uid(gateway_uid: Optional[str]) -> None:
+    """Set the active gateway_uid for this thread (None clears it)."""
+    _thread_local.gateway_uid = gateway_uid
+
+
+def current_gateway_uid() -> Optional[str]:
+    """Return the active gateway_uid for this thread, or None if not set."""
+    return getattr(_thread_local, "gateway_uid", None)
 
 
 class Database:

--- a/custom_components/vimar_byme_plus/vimar/database/repository/ambient_repo.py
+++ b/custom_components/vimar_byme_plus/vimar/database/repository/ambient_repo.py
@@ -1,4 +1,5 @@
 from sqlite3 import Connection
+from typing import Optional
 
 from ...model.repository.user_ambient import UserAmbient
 from .base_repo import BaseRepo
@@ -8,6 +9,7 @@ class AmbientRepo(BaseRepo):
     def __init__(self, connection: Connection):
         super().__init__(connection)
         self.create_table()
+        self.alter_table()
 
     def create_table(self):
         query = """
@@ -17,37 +19,67 @@ class AmbientRepo(BaseRepo):
                 hash TEXT NOT NULL,
                 idambient INTEGER NOT NULL,
                 idparent INTEGER,
-                name TEXT NOT NULL
+                name TEXT NOT NULL,
+                gateway_uid TEXT
             );
             """
         self.execute(query)
 
-    def get_ids(self) -> list[int]:
-        query = "SELECT idambient FROM ambients;"
+    def alter_table(self):
+        query = "PRAGMA table_info(ambients);"
         cursor = self.cursor().execute(query)
+        columns = [column[1] for column in cursor.fetchall()]
+        if "gateway_uid" not in columns:
+            cursor.execute("ALTER TABLE ambients ADD COLUMN gateway_uid TEXT;")
+
+    def get_ids(self, gateway_uid: Optional[str] = None) -> list[int]:
+        if gateway_uid:
+            query = "SELECT idambient FROM ambients WHERE gateway_uid = ? OR gateway_uid IS NULL;"
+            cursor = self.cursor().execute(query, (gateway_uid,))
+        else:
+            query = "SELECT idambient FROM ambients;"
+            cursor = self.cursor().execute(query)
         record = cursor.fetchall()
         return record if record else []
 
-    def replace_all(self, ambients: list[UserAmbient]):
-        self.delete_all()
-        self.insert_all(ambients)
+    def replace_all(
+        self, ambients: list[UserAmbient], gateway_uid: Optional[str] = None
+    ):
+        # Only wipe rows for *this* gateway, otherwise the second gateway's
+        # ambient discovery would erase the first gateway's ambients and
+        # break the components<->ambients JOIN in component_repo.get_all
+        # (issue #34, BUG#3 — ambients-scoping completion).
+        self.delete_all(gateway_uid=gateway_uid)
+        self.insert_all(ambients, gateway_uid=gateway_uid)
 
-    def delete_all(self):
-        query = "DELETE FROM ambients;"
-        self.execute(query)
+    def delete_all(self, gateway_uid: Optional[str] = None):
+        if gateway_uid:
+            query = "DELETE FROM ambients WHERE gateway_uid = ? OR gateway_uid IS NULL;"
+            self.execute(query, (gateway_uid,))
+        else:
+            query = "DELETE FROM ambients;"
+            self.execute(query)
 
-    def insert_all(self, ambients: list[UserAmbient]):
-        ambients_data = [ambient.to_tuple() for ambient in ambients]
+    def insert_all(
+        self, ambients: list[UserAmbient], gateway_uid: Optional[str] = None
+    ):
+        ambients_data = [(*ambient.to_tuple(), gateway_uid) for ambient in ambients]
         query = """
             INSERT INTO ambients
-                (dictKey, hash, idambient, idparent, name)
+                (dictKey, hash, idambient, idparent, name, gateway_uid)
             VALUES
-                (?, ?, ?, ?, ?);
+                (?, ?, ?, ?, ?, ?);
         """
         self.execute(query, ambients_data)
 
-    def get_name_by_id(self, idambient: int) -> str:
-        query = "SELECT name FROM ambients WHERE idambient = ?;"
-        cursor = self.cursor().execute(query, (idambient,))
+    def get_name_by_id(
+        self, idambient: int, gateway_uid: Optional[str] = None
+    ) -> str:
+        if gateway_uid:
+            query = "SELECT name FROM ambients WHERE idambient = ? AND (gateway_uid = ? OR gateway_uid IS NULL);"
+            cursor = self.cursor().execute(query, (idambient, gateway_uid))
+        else:
+            query = "SELECT name FROM ambients WHERE idambient = ?;"
+            cursor = self.cursor().execute(query, (idambient,))
         result = cursor.fetchone()
         return result[0] if result else None

--- a/custom_components/vimar_byme_plus/vimar/database/repository/base_repo.py
+++ b/custom_components/vimar_byme_plus/vimar/database/repository/base_repo.py
@@ -1,3 +1,4 @@
+import threading
 from sqlite3 import Connection, Cursor, Error
 
 from ...utils.logger import log_debug, log_error
@@ -6,6 +7,25 @@ from ...utils.logger import log_debug, log_error
 class BaseRepo:
     _connection: Connection
 
+    # Class-level lock guarding the shared sqlite3 Connection.
+    #
+    # Every repo instance receives the same `Database.instance()` connection,
+    # which is opened with `check_same_thread=False` so it can be used from
+    # the WS callback threads of multiple OperationalService coordinators.
+    # Without serialisation, two coordinators starting up at the same time
+    # (e.g. right after an HA restart with two paired gateways) interleave
+    # `cursor.execute() + connection.commit()` calls on the same Connection,
+    # which sqlite3 surfaces as `cannot start a transaction within a
+    # transaction` / `bad parameter or other API misuse`. The integration
+    # then loses some of the schema/state writes (visible symptom: doubled
+    # `components` rows after sfdiscovery, entities stuck `unavailable`
+    # until the user manually reloads the config entries from the UI).
+    #
+    # Holding the lock around the entire execute → commit pair is the
+    # smallest correct fix; the operations are short and not on the hot
+    # path so the contention is negligible.
+    _lock = threading.Lock()
+
     def __init__(self, connection: Connection):
         self._connection = connection
 
@@ -13,16 +33,17 @@ class BaseRepo:
         return self._connection.cursor()
 
     def execute(self, query, params: tuple = ()):
-        cursor = self.cursor()
-        try:
-            log_debug(__name__, f"Executing query: {query} with params: {params}")
-            if params and isinstance(params, (tuple)):
-                cursor.execute(query, params)
-            elif params and isinstance(params, list):
-                cursor.executemany(query, params)
-            else:
-                cursor.execute(query)
-            self._connection.commit()
-            log_debug(__name__, "Query executed successfully")
-        except Error as e:
-            log_error(__name__, f"The error '{e}' occurred")
+        with self._lock:
+            cursor = self.cursor()
+            try:
+                log_debug(__name__, f"Executing query: {query} with params: {params}")
+                if params and isinstance(params, (tuple)):
+                    cursor.execute(query, params)
+                elif params and isinstance(params, list):
+                    cursor.executemany(query, params)
+                else:
+                    cursor.execute(query)
+                self._connection.commit()
+                log_debug(__name__, "Query executed successfully")
+            except Error as e:
+                log_error(__name__, f"The error '{e}' occurred")

--- a/custom_components/vimar_byme_plus/vimar/database/repository/component_repo.py
+++ b/custom_components/vimar_byme_plus/vimar/database/repository/component_repo.py
@@ -1,5 +1,5 @@
 from sqlite3 import Connection
-from typing import Any
+from typing import Any, Optional
 
 from ...model.repository.user_ambient import UserAmbient
 from ...model.repository.user_component import UserComponent
@@ -14,6 +14,7 @@ class ComponentRepo(BaseRepo):
     def __init__(self, connection: Connection, element_repo: ElementRepo):
         super().__init__(connection)
         self.create_table()
+        self.alter_table()
         self.element_repo = element_repo
 
     def create_table(self):
@@ -26,63 +27,118 @@ class ComponentRepo(BaseRepo):
                 name TEXT NOT NULL,
                 sftype TEXT NOT NULL,
                 sstype TEXT NOT NULL,
+                gateway_uid TEXT,
                 FOREIGN KEY (idambient) REFERENCES ambients (idambient)
             );
             """
         self.execute(query)
 
-    def replace_all(self, components: list[UserComponent]):
-        self.delete_all()
-        self.insert_all(components)
+    def alter_table(self):
+        query = "PRAGMA table_info(components);"
+        cursor = self.cursor().execute(query)
+        columns = [column[1] for column in cursor.fetchall()]
+        if "gateway_uid" not in columns:
+            cursor.execute("ALTER TABLE components ADD COLUMN gateway_uid TEXT;")
 
-    def delete_all(self):
-        self.element_repo.delete_all()
-        self._delete_all()
+    def replace_all(
+        self, components: list[UserComponent], gateway_uid: Optional[str] = None
+    ):
+        # Only wipe rows belonging to *this* gateway, so other paired gateways
+        # keep their components in the shared DB (issue #34, BUG#3).
+        self.delete_all(gateway_uid=gateway_uid)
+        self.insert_all(components, gateway_uid=gateway_uid)
 
-    def _delete_all(self):
-        query = "DELETE FROM components;"
-        self.execute(query)
+    def delete_all(self, gateway_uid: Optional[str] = None):
+        self.element_repo.delete_all(gateway_uid=gateway_uid)
+        self._delete_all(gateway_uid=gateway_uid)
 
-    def insert_all(self, components: list[UserComponent]):
-        self._insert_all(components)
-        self.element_repo.insert_all(components)
+    def _delete_all(self, gateway_uid: Optional[str] = None):
+        if gateway_uid:
+            query = "DELETE FROM components WHERE gateway_uid = ? OR gateway_uid IS NULL;"
+            self.execute(query, (gateway_uid,))
+        else:
+            query = "DELETE FROM components;"
+            self.execute(query)
 
-    def _insert_all(self, components: list[UserComponent]):
-        components_data = [component.to_tuple() for component in components]
+    def insert_all(
+        self, components: list[UserComponent], gateway_uid: Optional[str] = None
+    ):
+        self._insert_all(components, gateway_uid=gateway_uid)
+        self.element_repo.insert_all(components, gateway_uid=gateway_uid)
+
+    def _insert_all(
+        self, components: list[UserComponent], gateway_uid: Optional[str] = None
+    ):
+        components_data = [
+            (*component.to_tuple(), gateway_uid) for component in components
+        ]
         query = """
             INSERT INTO components
-                (dictKey, idambient, idsf, name, sftype, sstype)
+                (dictKey, idambient, idsf, name, sftype, sstype, gateway_uid)
             VALUES
-                (?, ?, ?, ?, ?, ?);
+                (?, ?, ?, ?, ?, ?, ?);
         """
         self.execute(query, components_data)
 
-    def get_all(self) -> list[UserComponent]:
-        query = """
-            SELECT
-                c.dictKey, c.idambient, c.idsf, c.name, c.sftype, c.sstype,
-                e.id, e.enable, e.sfetype, e.value, e.updated,
-                a.dictKey, a.hash, a.idambient, a.idparent, a.name
-            FROM
-                components c
-            JOIN
-                elements e ON c.idsf = e.idcomponent
-            JOIN
-                ambients a ON c.idambient = a.idambient;
-
-        """
-        cursor = self.cursor().execute(query)
+    def get_all(self, gateway_uid: Optional[str] = None) -> list[UserComponent]:
+        # Join elements/ambients also filtered by gateway_uid where applicable.
+        # Same-idsf collisions across gateways are now safe because both
+        # components and elements carry the gateway_uid scope.
+        # LEFT JOIN on ambients so a missing/wiped ambient row never drops
+        # the component (defensive: ambient discovery for a different gateway
+        # used to wipe rows globally — see issue #34 BUG#3 ambients-scoping).
+        if gateway_uid:
+            query = """
+                SELECT
+                    c.dictKey, c.idambient, c.idsf, c.name, c.sftype, c.sstype,
+                    e.id, e.enable, e.sfetype, e.value, e.updated,
+                    a.dictKey, a.hash, a.idambient, a.idparent, a.name
+                FROM
+                    components c
+                JOIN
+                    elements e ON c.idsf = e.idcomponent
+                    AND (e.gateway_uid = c.gateway_uid OR e.gateway_uid IS NULL)
+                LEFT JOIN
+                    ambients a ON c.idambient = a.idambient
+                    AND (a.gateway_uid = c.gateway_uid OR a.gateway_uid IS NULL)
+                WHERE
+                    c.gateway_uid = ? OR c.gateway_uid IS NULL;
+            """
+            cursor = self.cursor().execute(query, (gateway_uid,))
+        else:
+            query = """
+                SELECT
+                    c.dictKey, c.idambient, c.idsf, c.name, c.sftype, c.sstype,
+                    e.id, e.enable, e.sfetype, e.value, e.updated,
+                    a.dictKey, a.hash, a.idambient, a.idparent, a.name
+                FROM
+                    components c
+                JOIN
+                    elements e ON c.idsf = e.idcomponent
+                LEFT JOIN
+                    ambients a ON c.idambient = a.idambient;
+            """
+            cursor = self.cursor().execute(query)
         rows = cursor.fetchall()
         return self._get_all(rows)
 
-    def get_component_of_type(self, sftype: str) -> list[UserComponent]:
-        query = """
-            SELECT dictKey, idambient, idsf, name, sftype, sstype
-            FROM components
-            WHERE sftype = ?;
-        """
-
-        cursor = self.cursor().execute(query, (sftype,))
+    def get_component_of_type(
+        self, sftype: str, gateway_uid: Optional[str] = None
+    ) -> list[UserComponent]:
+        if gateway_uid:
+            query = """
+                SELECT dictKey, idambient, idsf, name, sftype, sstype
+                FROM components
+                WHERE sftype = ? AND (gateway_uid = ? OR gateway_uid IS NULL);
+            """
+            cursor = self.cursor().execute(query, (sftype, gateway_uid))
+        else:
+            query = """
+                SELECT dictKey, idambient, idsf, name, sftype, sstype
+                FROM components
+                WHERE sftype = ?;
+            """
+            cursor = self.cursor().execute(query, (sftype,))
         rows = cursor.fetchall()
         return [self._get_values(row) for row in rows]
 

--- a/custom_components/vimar_byme_plus/vimar/database/repository/element_repo.py
+++ b/custom_components/vimar_byme_plus/vimar/database/repository/element_repo.py
@@ -1,4 +1,5 @@
 from sqlite3 import Connection
+from typing import Optional
 
 from ...model.repository.user_component import UserComponent
 from ...model.repository.user_element import UserElement
@@ -20,6 +21,7 @@ class ElementRepo(BaseRepo):
                 sfetype TEXT NOT NULL,
                 value TEXT,
                 updated TIMESTAMP,
+                gateway_uid TEXT,
                 FOREIGN KEY (idcomponent) REFERENCES components (idsf)
             );
         """
@@ -36,48 +38,82 @@ class ElementRepo(BaseRepo):
             UPDATE elements SET updated = CURRENT_TIMESTAMP WHERE updated IS NULL;
             """
             cursor.execute(set_update)
+        if "gateway_uid" not in columns:
+            cursor.execute("ALTER TABLE elements ADD COLUMN gateway_uid TEXT;")
 
-    def get_value_by_id(self, idcomponent: str, type: str) -> str:
-        elements_data = (idcomponent, type)
-        query = """
-            SELECT value
-            FROM elements
-            WHERE idcomponent = ? AND sfetype = ?;
-        """
-        self.execute(query, elements_data)
-        cursor = self.cursor().execute(query, elements_data)
+    def get_value_by_id(
+        self, idcomponent: str, type: str, gateway_uid: Optional[str] = None
+    ) -> str:
+        if gateway_uid:
+            query = """
+                SELECT value
+                FROM elements
+                WHERE idcomponent = ? AND sfetype = ?
+                  AND (gateway_uid = ? OR gateway_uid IS NULL);
+            """
+            cursor = self.cursor().execute(query, (idcomponent, type, gateway_uid))
+        else:
+            query = """
+                SELECT value
+                FROM elements
+                WHERE idcomponent = ? AND sfetype = ?;
+            """
+            cursor = self.cursor().execute(query, (idcomponent, type))
         result = cursor.fetchone()
         return result[0] if result else None
 
-    def delete_all(self):
-        query = "DELETE FROM elements;"
-        self.execute(query)
+    def delete_all(self, gateway_uid: Optional[str] = None):
+        if gateway_uid:
+            query = "DELETE FROM elements WHERE gateway_uid = ? OR gateway_uid IS NULL;"
+            self.execute(query, (gateway_uid,))
+        else:
+            query = "DELETE FROM elements;"
+            self.execute(query)
 
-    def insert_all(self, components: list[UserComponent]):
+    def insert_all(
+        self, components: list[UserComponent], gateway_uid: Optional[str] = None
+    ):
         elements = self._get_all_elements(components)
-        self._insert_all(elements)
+        self._insert_all(elements, gateway_uid=gateway_uid)
 
-    def update_all(self, components: list[UserComponent]):
+    def update_all(
+        self, components: list[UserComponent], gateway_uid: Optional[str] = None
+    ):
         elements = self._get_all_elements(components)
-        self._update_all(elements)
+        self._update_all(elements, gateway_uid=gateway_uid)
 
-    def _insert_all(self, elements: list[UserElement]):
-        elements_data = [element.to_tuple() for element in elements]
+    def _insert_all(
+        self, elements: list[UserElement], gateway_uid: Optional[str] = None
+    ):
+        elements_data = [(*element.to_tuple(), gateway_uid) for element in elements]
         query = """
             INSERT INTO elements
-                (enable, idcomponent, sfetype, value, updated)
+                (enable, idcomponent, sfetype, value, updated, gateway_uid)
             VALUES
-                (?, ?, ?, ?, ?);
+                (?, ?, ?, ?, ?, ?);
         """
         self.execute(query, elements_data)
 
-    def _update_all(self, elements: list[UserElement]):
-        elements_data = [element.to_tuple_for_update() for element in elements]
-        query = """
-            UPDATE elements
-            SET enable = ?, value = ?, updated = ?
-            WHERE idcomponent = ? AND sfetype = ?;
-        """
+    def _update_all(
+        self, elements: list[UserElement], gateway_uid: Optional[str] = None
+    ):
+        if gateway_uid:
+            elements_data = [
+                (*element.to_tuple_for_update(), gateway_uid) for element in elements
+            ]
+            query = """
+                UPDATE elements
+                SET enable = ?, value = ?, updated = ?
+                WHERE idcomponent = ? AND sfetype = ?
+                  AND (gateway_uid = ? OR gateway_uid IS NULL);
+            """
+        else:
+            elements_data = [element.to_tuple_for_update() for element in elements]
+            query = """
+                UPDATE elements
+                SET enable = ?, value = ?, updated = ?
+                WHERE idcomponent = ? AND sfetype = ?;
+            """
         self.execute(query, elements_data)
 
     def _get_all_elements(self, components: list[UserComponent]) -> list[UserElement]:

--- a/custom_components/vimar_byme_plus/vimar/database/repository/user_repo.py
+++ b/custom_components/vimar_byme_plus/vimar/database/repository/user_repo.py
@@ -1,4 +1,5 @@
 from sqlite3 import Connection
+from typing import Optional
 
 from ...model.repository.user_credentials import UserCredentials
 from .base_repo import BaseRepo
@@ -18,7 +19,8 @@ class UserRepo(BaseRepo):
                 setup_code TEXT,
                 useruid TEXT,
                 password TEXT,
-                plant_name TEXT
+                plant_name TEXT,
+                gateway_uid TEXT
             );
         """
         self.execute(query)
@@ -30,15 +32,35 @@ class UserRepo(BaseRepo):
         if "plant_name" not in columns:
             alter = "ALTER TABLE users ADD COLUMN plant_name TEXT;"
             cursor.execute(alter)
+        if "gateway_uid" not in columns:
+            alter = "ALTER TABLE users ADD COLUMN gateway_uid TEXT;"
+            cursor.execute(alter)
 
-    def get_current_user(self) -> UserCredentials:
-        query = """
-            SELECT
-                username, setup_code, useruid, password, plant_name
-            FROM users
-            LIMIT 1
+    def get_current_user(self, gateway_uid: Optional[str] = None) -> UserCredentials:
+        """Return credentials for the given gateway, or any if gateway_uid is None.
+
+        Backward-compatible: rows that pre-date the multi-gateway scoping
+        have gateway_uid = NULL and are still returned (until the
+        operational coordinator claims them at startup).
         """
-        cursor = self.cursor().execute(query)
+        if gateway_uid:
+            # Prefer the row tagged for this gateway; fall back to a NULL row
+            # left over from the pre-scoped schema.
+            query = """
+                SELECT username, setup_code, useruid, password, plant_name
+                FROM users
+                WHERE gateway_uid = ? OR gateway_uid IS NULL
+                ORDER BY (gateway_uid IS NULL) ASC
+                LIMIT 1
+            """
+            cursor = self.cursor().execute(query, (gateway_uid,))
+        else:
+            query = """
+                SELECT username, setup_code, useruid, password, plant_name
+                FROM users
+                LIMIT 1
+            """
+            cursor = self.cursor().execute(query)
         record = cursor.fetchone()
         if not record:
             return None
@@ -51,38 +73,61 @@ class UserRepo(BaseRepo):
             plant_name=plant_name,
         )
 
-    def insert(self, credentials: UserCredentials):
+    def insert(self, credentials: UserCredentials, gateway_uid: Optional[str] = None):
         query = """
             INSERT INTO users
-                (setup_code, username)
+                (setup_code, username, gateway_uid)
             VALUES
-                (?, ?);
+                (?, ?, ?);
         """
-        self.execute(query, (credentials.setup_code, credentials.username))
+        self.execute(query, (credentials.setup_code, credentials.username, gateway_uid))
 
-    def insert_setup_code(self, username: str, setup_code: str):
+    def insert_setup_code(
+        self, username: str, setup_code: str, gateway_uid: Optional[str] = None
+    ):
         credentials = UserCredentials(username=username, setup_code=setup_code)
-        self.delete_all()
-        self.insert(credentials)
+        # Only delete the row(s) for this specific gateway, so other paired
+        # gateways keep their credentials. Without scoping, the second pair
+        # in a multi-gateway setup would wipe the first one (issue #34, BUG#3).
+        self.delete_all(gateway_uid=gateway_uid)
+        self.insert(credentials, gateway_uid=gateway_uid)
 
-    def delete_all(self):
-        query = "DELETE FROM users;"
-        self.execute(query)
+    def delete_all(self, gateway_uid: Optional[str] = None):
+        if gateway_uid:
+            query = "DELETE FROM users WHERE gateway_uid = ? OR gateway_uid IS NULL;"
+            self.execute(query, (gateway_uid,))
+        else:
+            query = "DELETE FROM users;"
+            self.execute(query)
 
-    def update(self, credentials: UserCredentials):
-        query = """
-            UPDATE users
-            SET useruid = ?, password = ?, setup_code = ?, plant_name = ?
-            WHERE username = ?;
-        """
-        values = (
-            credentials.useruid,
-            credentials.password,
-            None,
-            credentials.plant_name,
-            credentials.username,
-        )
-        self.execute(
-            query,
-            values,
-        )
+    def update(
+        self, credentials: UserCredentials, gateway_uid: Optional[str] = None
+    ):
+        if gateway_uid:
+            query = """
+                UPDATE users
+                SET useruid = ?, password = ?, setup_code = ?, plant_name = ?
+                WHERE username = ? AND (gateway_uid = ? OR gateway_uid IS NULL);
+            """
+            values = (
+                credentials.useruid,
+                credentials.password,
+                None,
+                credentials.plant_name,
+                credentials.username,
+                gateway_uid,
+            )
+        else:
+            query = """
+                UPDATE users
+                SET useruid = ?, password = ?, setup_code = ?, plant_name = ?
+                WHERE username = ?;
+            """
+            values = (
+                credentials.useruid,
+                credentials.password,
+                None,
+                credentials.plant_name,
+                credentials.username,
+            )
+        self.execute(query, values)

--- a/custom_components/vimar_byme_plus/vimar/service/association_service.py
+++ b/custom_components/vimar_byme_plus/vimar/service/association_service.py
@@ -1,7 +1,7 @@
 from ..client.authenticator_client import AuthenticatorClient
 from ..client.web_service.sync_attach_phase import SyncAttachPhase
 from ..client.web_service.sync_session_phase import SyncSessionPhase
-from ..database.database import Database
+from ..database.database import Database, set_current_gateway_uid
 from ..model.exceptions import VimarErrorResponseException
 from ..model.gateway.gateway_info import GatewayInfo
 from ..model.repository.user_credentials import UserCredentials
@@ -89,16 +89,20 @@ class AssociationService:
 
     def get_signed_credentials(self) -> UserCredentials:
         client = self._authenticator_client
-        credentials = self._user_repo.get_current_user()
+        gateway_uid = self.gateway_info.deviceuid
+        set_current_gateway_uid(gateway_uid)
+        credentials = self._user_repo.get_current_user(gateway_uid=gateway_uid)
         if credentials and credentials.password:
             return credentials
         signed_credentials = client.get_association_credentials(credentials)
-        self._user_repo.update(signed_credentials)
+        self._user_repo.update(signed_credentials, gateway_uid=gateway_uid)
         return signed_credentials
 
     def save_attach_credentials(self, response: BaseResponse):
         client = self._authenticator_client
+        gateway_uid = self.gateway_info.deviceuid
+        set_current_gateway_uid(gateway_uid)
         credentials = UserCredentials.obj_from_dict(response)
         signed_credentials = client.get_operational_credentials(credentials)
         signed_credentials.plant_name = credentials.plant_name
-        self._user_repo.update(signed_credentials)
+        self._user_repo.update(signed_credentials, gateway_uid=gateway_uid)

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/base_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/base_action_handler.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-from ....database.database import Database
+from ....database.database import Database, current_gateway_uid
 from ....model.component.vimar_action import VimarAction
 from ....model.component.vimar_component import VimarComponent
 from ....model.enum.action_type import ActionType
@@ -29,34 +29,36 @@ class BaseActionHandler(HandlerInterface):
 
     def save_user_credentials(self, response: dict):
         credentials = UserCredentials.obj_from_dict(response)
-        self._user_repo.update(credentials)
+        self._user_repo.update(credentials, gateway_uid=current_gateway_uid())
 
     def save_ambients(self, response: dict):
         ambients = UserAmbient.list_from_dict(response)
         log_info(__name__, f"Ambients retrieved: {len(ambients)}")
-        self._ambient_repo.replace_all(ambients)
+        self._ambient_repo.replace_all(ambients, gateway_uid=current_gateway_uid())
 
     def save_components(self, response: dict):
         components = UserComponent.list_from_response(response)
         log_info(__name__, f"Components retrieved: {len(components)}")
-        self._component_repo.replace_all(components)
+        self._component_repo.replace_all(components, gateway_uid=current_gateway_uid())
 
     def save_component_changes(self, request: dict):
         components = UserComponent.list_from_request(request)
         log_info(__name__, f"Changes retrieved: {len(components)}")
-        self._element_repo.update_all(components)
+        self._element_repo.update_all(components, gateway_uid=current_gateway_uid())
 
     def get_user_credentials(self) -> UserCredentials:
-        return self._user_repo.get_current_user()
+        return self._user_repo.get_current_user(gateway_uid=current_gateway_uid())
 
     def get_all_ambient_ids(self) -> list[int]:
         return self._ambient_repo.get_ids()
 
     def get_all_components(self) -> list[UserComponent]:
-        return self._component_repo.get_all()
+        return self._component_repo.get_all(gateway_uid=current_gateway_uid())
 
     def get_components(self, type: ComponentType) -> list[UserComponent]:
-        return self._component_repo.get_component_of_type(type.value)
+        return self._component_repo.get_component_of_type(
+            type.value, gateway_uid=current_gateway_uid()
+        )
 
     def _action(self, id: str, sfetype: SfeType, value: Any) -> VimarAction:
         return VimarAction(idsf=id, sfetype=sfetype.value, value=str(value))

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/base_handler_message.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/base_handler_message.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from ....database.database import Database
+from ....database.database import Database, current_gateway_uid
 from ....model.enum.component_type import ComponentType
 from ....model.repository.user_ambient import UserAmbient
 from ....model.repository.user_component import UserComponent
@@ -36,31 +36,33 @@ class BaseMessageHandler(HandlerInterface):
 
     def save_user_credentials(self, response: dict):
         credentials = UserCredentials.obj_from_dict(response)
-        self._user_repo.update(credentials)
+        self._user_repo.update(credentials, gateway_uid=current_gateway_uid())
 
     def save_ambients(self, response: dict):
         ambients = UserAmbient.list_from_dict(response)
         log_info(__name__, f"Ambients retrieved: {len(ambients)}")
-        self._ambient_repo.replace_all(ambients)
+        self._ambient_repo.replace_all(ambients, gateway_uid=current_gateway_uid())
 
     def save_components(self, response: dict):
         components = UserComponent.list_from_response(response)
         log_info(__name__, f"Components retrieved: {len(components)}")
-        self._component_repo.replace_all(components)
+        self._component_repo.replace_all(components, gateway_uid=current_gateway_uid())
 
     def save_component_changes(self, request: dict):
         components = UserComponent.list_from_request(request)
         log_info(__name__, f"Changes retrieved: {len(components)}")
-        self._element_repo.update_all(components)
+        self._element_repo.update_all(components, gateway_uid=current_gateway_uid())
 
     def get_user_credentials(self) -> UserCredentials:
-        return self._user_repo.get_current_user()
+        return self._user_repo.get_current_user(gateway_uid=current_gateway_uid())
 
     def get_all_ambient_ids(self) -> list[int]:
         return self._ambient_repo.get_ids()
 
     def get_all_components(self) -> list[UserComponent]:
-        return self._component_repo.get_all()
+        return self._component_repo.get_all(gateway_uid=current_gateway_uid())
 
     def get_components(self, type: ComponentType) -> list[UserComponent]:
-        return self._component_repo.get_component_of_type(type.value)
+        return self._component_repo.get_component_of_type(
+            type.value, gateway_uid=current_gateway_uid()
+        )

--- a/custom_components/vimar_byme_plus/vimar/service/operational_service.py
+++ b/custom_components/vimar_byme_plus/vimar/service/operational_service.py
@@ -1,12 +1,16 @@
 from collections.abc import Coroutine
+import logging
+import logging.handlers
+import os
 import time
+from pathlib import Path
 from typing import Any
 
 from websocket import WebSocketConnectionClosedException
 
 from ..client.web_service.sync_session_phase import SyncSessionPhase
 from ..client.web_service.ws_attach_phase import WSAttachPhase
-from ..database.database import Database
+from ..database.database import Database, set_current_gateway_uid
 from ..model.component.vimar_component import VimarComponent
 from ..model.enum.action_type import ActionType
 from ..model.enum.integration_phase import IntegrationPhase
@@ -24,6 +28,87 @@ from .handler.message_handler.message_handler import MessageHandler
 type Update = Coroutine[Any, Any, None]
 
 
+# ---------------------------------------------------------------------------
+# Local WS message dump (NOT shipped in the upstream PR — local debug only).
+# Rotates the log at midnight, keeps 15 daily files, and prunes oldest files
+# whenever the bundle exceeds 500 MB total. Whichever cap (15 days or 500 MB)
+# is hit first wins.
+# ---------------------------------------------------------------------------
+_DUMP_PATH = "/config/vimar_ws_dump.log"
+_DUMP_RETENTION_DAYS = 15
+_DUMP_MAX_TOTAL_BYTES = 500 * 1024 * 1024  # 500 MB
+_DUMP_SIZE_CHECK_EVERY = 500  # writes between size-cap sweeps
+_dump_write_count = 0
+
+
+def _build_dump_logger() -> logging.Logger:
+    logger = logging.getLogger("vimar_byme_plus.ws_dump")
+    if logger.handlers:
+        return logger
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    try:
+        handler = logging.handlers.TimedRotatingFileHandler(
+            _DUMP_PATH,
+            when="midnight",
+            backupCount=_DUMP_RETENTION_DAYS,
+            encoding="utf-8",
+        )
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+    except Exception:  # noqa: BLE001
+        logger.addHandler(logging.NullHandler())
+    return logger
+
+
+_DUMP_LOGGER = _build_dump_logger()
+
+
+def _enforce_dump_size_cap() -> None:
+    """Delete oldest rotated dump files while the bundle exceeds the cap."""
+    try:
+        path = Path(_DUMP_PATH)
+        files = sorted(
+            path.parent.glob(path.name + "*"),
+            key=lambda p: p.stat().st_mtime,
+        )
+        total = sum(p.stat().st_size for p in files)
+        # Always keep the live (newest) file even if it alone exceeds cap.
+        for old in files[:-1]:
+            if total <= _DUMP_MAX_TOTAL_BYTES:
+                break
+            try:
+                size = old.stat().st_size
+                old.unlink()
+                total -= size
+            except OSError:
+                pass
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _dump_ws_message(gateway_uid: str, message: BaseRequestResponse) -> None:
+    global _dump_write_count
+    try:
+        ts = time.strftime("%H:%M:%S")
+        header = (
+            f"--- {ts} gw={gateway_uid} "
+            f"type={type(message).__name__} "
+            f"function={getattr(message, 'function', '?')} "
+            f"msgid={getattr(message, 'msgid', '?')} ---"
+        )
+        try:
+            payload = message.to_json()
+        except Exception:  # noqa: BLE001
+            payload = repr(message)
+        _DUMP_LOGGER.info("%s\n%s", header, payload)
+        _dump_write_count += 1
+        if _dump_write_count % _DUMP_SIZE_CHECK_EVERY == 0:
+            _enforce_dump_size_cap()
+    except Exception:  # noqa: BLE001
+        pass
+
+
 class OperationalService:
     gateway_address: str
     session_port: int
@@ -39,6 +124,9 @@ class OperationalService:
 
     _web_socket: WSAttachPhase = None
     _user_repo = Database.instance().user_repo
+    _component_repo = Database.instance().component_repo
+    _ambient_repo = Database.instance().ambient_repo
+    _bootstrapped: bool = False
 
     def __init__(self, gateway_info: GatewayInfo, callback: Update) -> None:
         """Initialize Vimar intagration."""
@@ -53,6 +141,14 @@ class OperationalService:
 
     def connect(self):
         """Handle the connection Vimar WebSocket connection."""
+        # Tag this thread with the active gateway so any handler invoked
+        # from the WS callbacks can scope DB queries correctly.
+        set_current_gateway_uid(self.gateway_info.deviceuid)
+        # One-shot migration: rows that pre-date the multi-gateway scoping
+        # have gateway_uid = NULL. Claim them for whichever gateway connects
+        # first. Only safe when the fork was previously single-gateway, but
+        # that's exactly the case we're upgrading from.
+        self._claim_legacy_rows()
         try:
             self.clean()
             self.sync_session_phase()
@@ -64,6 +160,32 @@ class OperationalService:
                 self.connect()
             else:
                 raise VimarErrorResponseException(exc) from exc
+
+    def _claim_legacy_rows(self) -> None:
+        """Migrate pre-multi-gateway rows (gateway_uid IS NULL) to this gateway."""
+        uid = self.gateway_info.deviceuid
+        log_info(__name__, f"Attempting to claim legacy rows for {uid}")
+        # Use repo's own execute to keep transactions consistent
+        for repo, table in (
+            (self._user_repo, "users"),
+            (self._component_repo, "components"),
+            (self._ambient_repo, "ambients"),
+        ):
+            try:
+                repo.execute(
+                    f"UPDATE {table} SET gateway_uid = ? WHERE gateway_uid IS NULL",
+                    (uid,),
+                )
+            except Exception as exc:  # noqa: BLE001
+                log_info(__name__, f"Claim {table} failed: {exc}")
+        # element_repo: it's a sub-repo of component_repo, exposed via that one
+        try:
+            self._component_repo.element_repo.execute(
+                "UPDATE elements SET gateway_uid = ? WHERE gateway_uid IS NULL",
+                (uid,),
+            )
+        except Exception as exc:  # noqa: BLE001
+            log_info(__name__, f"Claim elements failed: {exc}")
 
     def send_action(self, component: VimarComponent, action_type: ActionType, *args):
         """Send a request coming from HomeAssistant to Gateway."""
@@ -110,10 +232,59 @@ class OperationalService:
     def on_attach_message_received(
         self, message: BaseRequestResponse
     ) -> BaseRequestResponse:
+        # Re-tag thread (defensive: callbacks may run on a separate thread).
+        set_current_gateway_uid(self.gateway_info.deviceuid)
+        # LOCAL DIAG (not in upstream PR): dump every WS message to a
+        # rotating log on /config. Rotation: midnight, 15 days kept,
+        # whole bundle capped at 500 MB (older days deleted first).
+        _dump_ws_message(self.gateway_info.deviceuid, message)
         response = self._message_handler.message_received(message)
         self.trigger_changes(message)
         self.handle_keep_alive(response)
+        self._maybe_bootstrap_states(message)
         return response
+
+    def _maybe_bootstrap_states(self, message: BaseRequestResponse) -> None:
+        """Request initial state of every component once after sfdiscovery.
+
+        Vimar gateways only push `changestatus` events when a value actually
+        changes. Devices that haven't moved since startup (lights left off,
+        thermostats at setpoint, shutters fully open or closed) never reach
+        HA, so their entities remain `unknown`/`off` until the user touches
+        them. Right after `sfdiscovery` the database has the full component
+        list, so we can ask the gateway for the current state of each idsf
+        once and let the normal change-status flow keep them in sync from
+        there.
+        """
+        if self._bootstrapped:
+            return
+        if isinstance(message, BaseRequest):
+            return  # only react to gateway responses
+        phase = IntegrationPhase.get(getattr(message, "function", None))
+        if phase != IntegrationPhase.SF_DISCOVERY:
+            return
+        try:
+            components = self._component_repo.get_all(
+                gateway_uid=self.gateway_info.deviceuid
+            )
+        except Exception as exc:  # noqa: BLE001
+            log_info(__name__, f"Bootstrap states: cannot read components: {exc}")
+            return
+        if not components:
+            return
+        log_info(
+            __name__,
+            f"Bootstrap states: requesting status of {len(components)} components",
+        )
+        for component in components:
+            try:
+                self.send_get_status(component.idsf)
+            except Exception as exc:  # noqa: BLE001
+                log_info(
+                    __name__,
+                    f"Bootstrap states: get_status failed for idsf={component.idsf}: {exc}",
+                )
+        self._bootstrapped = True
 
     def on_attach_error_message_received(
         self,
@@ -141,12 +312,30 @@ class OperationalService:
             self.connect()
 
     def trigger_changes(self, message: BaseRequestResponse):
+        """Fire the coordinator update callback when the DB has fresh data.
+
+        The coordinator only re-reads `home.db` when its `update_callback`
+        is invoked. Without this, every state mutation that touched the DB
+        but didn't go through `changestatus` (sfdiscovery snapshot at
+        connect, getstatus replies during bootstrap) would stay invisible
+        to the entities until the next change-status event — which for
+        idle devices may never come, leaving them `unavailable` after a
+        restart until the user manually reloads the config entry.
+        """
         if not self.update_callback:
             return
 
         phase = IntegrationPhase.get(message.function)
-        change_phase = IntegrationPhase.CHANGE_STATUS
-        if isinstance(message, BaseRequest) and phase == change_phase:
+        # CHANGE_STATUS: gateway-pushed runtime updates.
+        # SF_DISCOVERY: fresh component+element snapshot saved on (re)connect,
+        #               carries current state values inline.
+        # GET_STATUS: response to our bootstrap requests after sfdiscovery,
+        #             also writes element values to the DB.
+        if phase in (
+            IntegrationPhase.CHANGE_STATUS,
+            IntegrationPhase.SF_DISCOVERY,
+            IntegrationPhase.GET_STATUS,
+        ):
             self.update_callback()
 
     def handle_keep_alive(self, message: BaseRequestResponse):
@@ -163,7 +352,9 @@ class OperationalService:
 
     def _get_config_for_attach_phase(self) -> WebSocketConfig:
         config = self._get_config()
-        config.user_credentials = self._user_repo.get_current_user()
+        config.user_credentials = self._user_repo.get_current_user(
+            gateway_uid=self.gateway_info.deviceuid
+        )
         config.on_open_callback = self.on_attach_connection_opened
         config.on_message_callback = self.on_attach_message_received
         config.on_error_message_callback = self.on_attach_error_message_received

--- a/custom_components/vimar_byme_plus/vimar/service/operational_service.py
+++ b/custom_components/vimar_byme_plus/vimar/service/operational_service.py
@@ -261,20 +261,35 @@ class OperationalService:
         if isinstance(message, BaseRequest):
             return  # only react to gateway responses
         phase = IntegrationPhase.get(getattr(message, "function", None))
-        if phase != IntegrationPhase.SF_DISCOVERY:
+        # Trigger on REGISTER (the final response of the operational pipeline:
+        # session -> attach -> ambient_discovery -> sf_discovery -> register).
+        # By REGISTER the components table is fully populated *and committed*
+        # for this gateway, the WS attach is fully authenticated, and a
+        # concurrent second-gateway bootstrap cannot starve this one through
+        # a transient empty read on the shared singleton DB connection
+        # (observed: with two paired gateways, the slower one to finish
+        # sf_discovery would see 0 components and skip its bootstrap, leaving
+        # all its idle entities unavailable until the user manually reloaded).
+        if phase != IntegrationPhase.REGISTER:
             return
+        gw_uid = self.gateway_info.deviceuid
         try:
-            components = self._component_repo.get_all(
-                gateway_uid=self.gateway_info.deviceuid
-            )
+            components = self._component_repo.get_all(gateway_uid=gw_uid)
         except Exception as exc:  # noqa: BLE001
-            log_info(__name__, f"Bootstrap states: cannot read components: {exc}")
+            log_info(
+                __name__,
+                f"Bootstrap states[{gw_uid}]: cannot read components: {exc}",
+            )
             return
         if not components:
+            log_info(
+                __name__,
+                f"Bootstrap states[{gw_uid}]: 0 components in DB at REGISTER, skipping",
+            )
             return
         log_info(
             __name__,
-            f"Bootstrap states: requesting status of {len(components)} components",
+            f"Bootstrap states[{gw_uid}]: requesting status of {len(components)} components",
         )
         for component in components:
             try:
@@ -282,7 +297,7 @@ class OperationalService:
             except Exception as exc:  # noqa: BLE001
                 log_info(
                     __name__,
-                    f"Bootstrap states: get_status failed for idsf={component.idsf}: {exc}",
+                    f"Bootstrap states[{gw_uid}]: get_status failed for idsf={component.idsf}: {exc}",
                 )
         self._bootstrapped = True
 


### PR DESCRIPTION
# Multi-gateway support: 4 fixes (closes #34)

This branch contains the **safe-to-merge** subset of the work I started in #60.
It targets the four root causes that prevent two paired By-me Plus gateways
from coexisting on the same Home Assistant install. None of these fixes
touch user-facing entity_ids, so existing installs upgrade in-place.

I've left #60 open as a more complete (but riskier) snapshot — it also
includes the gateway-scoped `unique_id` rework. That part broke
user-renamed entity_ids twice in our production install, so I'd recommend
**merging this PR instead** and revisiting the entity_id rework only after
designing a migration helper that preserves user renames.

## What this PR does

| Bug | Commit | Files |
|---|---|---|
| **#2** Empty `home.db` deadlock | `Self-heal empty home.db on init` | `vimar/database/database.py` |
| **#3** Cross-gateway DB row stomping | `Scope DB rows per gateway for multi-gateway support` | 10 files (schema + repos + service + client + handlers) |
| **#3 race** sqlite "transaction within a transaction" on parallel coordinator startup | `Serialise base_repo writes with a class-level Lock` | `vimar/database/repository/base_repo.py` |
| **#4** Idle entities stuck `unavailable` after restart on multi-gateway installs | `Bootstrap component states on REGISTER, not SF_DISCOVERY` | `vimar/service/operational_service.py` + manifest bump 3.0.6 |

## Why each fix matters

### Bug #2 — `home.db` 0-byte trap

If a previous failed setup left the SQLite file at 0 bytes, `sqlite3.connect()`
keeps reopening the empty file forever and the integration never reaches the
operational phase. Two small defensive changes:

* If the file is 0 bytes on connect, remove it so a fresh schema can be
  written.
* After the repos run their CREATE TABLE statements in `__init__`, do one
  explicit `conn.commit()`. Without it, an exception later in setup leaves
  the schema unflushed and the file truly 0 bytes for the next attempt.

### Bug #3 — Multi-gateway DB scoping

The integration uses a process-singleton sqlite3 Database. With a single
paired gateway that's fine. With two paired gateways, the second pair's
`replace_all(...)` wipes the first one's `users`/`components`/`elements`/
`ambients` rows globally before re-inserting only its own.

This commit adds a `gateway_uid TEXT` column to all four tables (idempotent
ALTER on upgrade) and threads `gateway_uid` through every read and write.
Reads use `WHERE gateway_uid = ? OR gateway_uid IS NULL` so legacy rows
remain visible until claimed; a once-per-connect `_claim_legacy_rows()`
sweeps `gateway_uid IS NULL` rows for the connecting gateway.

A `set_current_gateway_uid` / `current_gateway_uid` thread-local helper
in `database.py` carries the active gateway through the WS callback
threads (`OperationalService`, `BaseMessageHandler`, `BaseActionHandler`)
without having to thread the parameter through every method by hand.

### Bug #3 race — `base_repo` serialisation

Even with per-gateway scoping, two coordinators starting up at the same
time still interleave `cursor.execute() + connection.commit()` on the
same Connection (opened with `check_same_thread=False`), which sqlite3
surfaces as `cannot start a transaction within a transaction` /
`bad parameter or other API misuse`. Symptom: doubled `components` rows
after sfdiscovery, entities stuck `unavailable` until the user manually
reloads the config entries.

A class-level `threading.Lock` around the entire `execute → commit` pair
is the smallest correct fix; the operations are short and not on the hot
path so the contention is negligible.

### Bug #4 — Bootstrap on REGISTER (not SF_DISCOVERY)

Vimar gateways only push `changestatus` events when a value actually
changes. Devices that haven't moved since startup (lights left off,
thermostats at setpoint, shutters fully open or closed) never reach HA,
so their entities remain `unknown` / `unavailable` until the user touches
them. The fix is to ask the gateway for the current state of every
component once after handshake, then let `changestatus` keep them in
sync.

The original implementation triggered this on the SF_DISCOVERY response.
On a single-gateway install that works. On a two-gateway install I hit
this race in production:

* Both gateways receive `sfdiscovery` response in parallel.
* Casa Trenno (faster) fires N `getstatus` requests; its entities populate.
* TrennoPT (slower) fires zero `getstatus`. Its
  `_component_repo.get_all(gateway_uid=PT)` returned 0 rows because A's
  mid-`replace_all` activity made the visible state inconsistent on the
  shared connection from B's reader thread perspective. Bootstrap exits
  silently via `if not components: return`.
* All idle TrennoPT entities (lights/switches that did not push a
  `changestatus` since boot) stay `unavailable` indefinitely, until the
  user reloads the config entry by hand.

Fix: trigger bootstrap on `IntegrationPhase.REGISTER` instead. REGISTER
is the final response in the operational handshake, so by the time it
arrives the same WS callback thread has *already* completed
`save_components` / `save_ambients` for **this** gateway and issued an
explicit `commit()` under the Lock. A read filtered by this gateway's
uid is then guaranteed to see this gateway's own rows.

Verified on the same install: after the fix and a restart, the WS dump
shows exactly N `getstatus` responses for TrennoPT immediately after
`register`, and 10/10 of its entities are now `available` with their
real states.

Also adds the gateway uid to bootstrap log lines and an explicit
"0 components in DB at REGISTER, skipping" branch so future regressions
are greppable.

## What this PR does NOT touch

* `base_entity.py` — kept upstream. The gateway-scoped `unique_id` /
  `identifiers` rework belongs in a follow-up that ships with a
  migration helper preserving user-renamed entity_ids.
* `__init__.py` — kept upstream. No `async_migrate_entry` here.
* `config_flow.py` — `VERSION` stays at 1.

The 9 idsf collisions between two paired gateways therefore still result
in HA device-merge in the registry, **but** in our 2-gateway production
install all collisions happen across different domains (light + switch /
light + climate), so HA keeps the entities themselves separate. We've
been running like this for several days with two gateways healthy.

## Diff stat

```
12 files changed, 613 insertions(+), 163 deletions(-)
```

## Supersedes

This PR supersedes #60 in scope: fixes #2, #3 (with follow-up + race),
#4 from that branch, in clean focused commits, without the
`base_entity.py` / `__init__.py` / `config_flow.py` changes that needed
more migration work.

Closes #34.
