### PR TITLE
Unintended Restarts: watchdog implementation added

### DIFF
--- a/custom_components/vimar_byme_plus/__init__.py
+++ b/custom_components/vimar_byme_plus/__init__.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import voluptuous as vol
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 
+from .const import DOMAIN
 from .coordinator import Coordinator
 from .vimar.model.exceptions import CodeNotValidException, VimarErrorResponseException
 
@@ -23,6 +26,12 @@ PLATFORMS = [
 
 type CoordinatorConfigEntry = ConfigEntry[Coordinator]
 
+SERVICE_RESTART = "restart"
+ATTR_ENTRY_ID = "entry_id"
+RESTART_SERVICE_SCHEMA = vol.Schema(
+    {vol.Optional(ATTR_ENTRY_ID): str}
+)
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: CoordinatorConfigEntry) -> bool:
     """Set up Hello World from a config entry."""
@@ -31,6 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: CoordinatorConfigEntry) 
     await start(coordinator)
     entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    _async_register_restart_service(hass)
     return True
 
 
@@ -53,3 +63,34 @@ async def start(coordinator: Coordinator):
         raise ConfigEntryAuthFailed(err) from err
     except CodeNotValidException as err:
         raise ConfigEntryAuthFailed(err) from err
+
+
+# --- Restart service ------------------------------------------------------
+# Registered once on first entry setup. Idempotent: the `has_service` guard
+# means subsequent entries don't re-register. Persists for the lifetime of
+# the HA process even if every entry is unloaded — minor cosmetic trade-off
+# for simpler lifecycle. Issue #33: provides a manual escape hatch on top
+# of the Coordinator watchdog.
+
+
+def _async_register_restart_service(hass: HomeAssistant) -> None:
+    if hass.services.has_service(DOMAIN, SERVICE_RESTART):
+        return
+
+    async def _handle_restart(call: ServiceCall) -> None:
+        target_id = call.data.get(ATTR_ENTRY_ID)
+        if target_id:
+            entry = hass.config_entries.async_get_entry(target_id)
+            if entry is None or entry.domain != DOMAIN:
+                raise HomeAssistantError(
+                    f"No vimar_byme_plus entry with id={target_id!r}"
+                )
+            entries = [entry]
+        else:
+            entries = list(hass.config_entries.async_entries(DOMAIN))
+        for entry in entries:
+            await hass.config_entries.async_reload(entry.entry_id)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_RESTART, _handle_restart, schema=RESTART_SERVICE_SCHEMA
+    )

--- a/custom_components/vimar_byme_plus/coordinator.py
+++ b/custom_components/vimar_byme_plus/coordinator.py
@@ -1,10 +1,13 @@
 """Provides the Vimar Coordinator."""
 
+from collections.abc import Callable
+from datetime import datetime, timedelta
 import logging
 
 from websocket import WebSocketConnectionClosedException
 
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import ADDRESS, CODE, DOMAIN, GATEWAY_ID, GATEWAY_NAME, HOST, PORT, PROTOCOL
@@ -15,6 +18,14 @@ from .vimar.model.gateway.gateway_info import GatewayInfo
 from .vimar.model.gateway.vimar_data import VimarData
 
 _LOGGER = logging.getLogger(__name__)
+
+# Watchdog tick frequency. The Vimar gateway pushes events on activity;
+# in idle moments the keep-alive (~90s) is the only traffic. A 5-minute
+# stale window is well above that, so a healthy connection never trips
+# the watchdog while a silent-stale one is detected within at most 10
+# minutes (one watchdog tick after crossing the threshold).
+_WATCHDOG_INTERVAL = timedelta(minutes=5)
+_STALE_THRESHOLD_SECONDS = 300
 
 
 class Coordinator(DataUpdateCoordinator[VimarData]):
@@ -28,6 +39,7 @@ class Coordinator(DataUpdateCoordinator[VimarData]):
         self.gateway_info = self._get_gateway_info(user_input)
         self.client = VimarClient(self.gateway_info, self.update_data)
         self.client.set_setup_code(user_input.get(CODE))
+        self._unsub_watchdog: Callable[[], None] | None = None
 
         super().__init__(hass, _LOGGER, name=DOMAIN)
 
@@ -39,9 +51,11 @@ class Coordinator(DataUpdateCoordinator[VimarData]):
         """Start coordinator processes."""
         self.client.operational_phase()
         self.update_data()
+        self._setup_watchdog()
 
     def stop(self):
         """Stop coordinator processes."""
+        self._teardown_watchdog()
         self.client.stop()
 
     def send(self, component: VimarComponent, action_type: ActionType, *args):
@@ -62,6 +76,38 @@ class Coordinator(DataUpdateCoordinator[VimarData]):
 
     async def _async_update_data(self) -> VimarData:
         return self.client.retrieve_data()
+
+    # --- Watchdog -----------------------------------------------------
+    # The integration relies on a daemon thread (`VimarServiceThread`)
+    # for the gateway WebSocket loop. If that thread dies — or the
+    # broker stops sending messages without closing the TCP — there is
+    # no internal mechanism to detect it: HA keeps reading stale data
+    # from the local DB. The watchdog runs on the HA event loop and
+    # forces a reconnect in either case.
+
+    def _setup_watchdog(self) -> None:
+        if self._unsub_watchdog is not None:
+            return
+        self._unsub_watchdog = async_track_time_interval(
+            self.hass, self._watchdog_tick, _WATCHDOG_INTERVAL
+        )
+
+    def _teardown_watchdog(self) -> None:
+        if self._unsub_watchdog is not None:
+            self._unsub_watchdog()
+            self._unsub_watchdog = None
+
+    async def _watchdog_tick(self, _now: datetime) -> None:
+        alive = self.client.is_thread_alive()
+        stale_seconds = self.client.seconds_since_last_message
+        if alive and stale_seconds < _STALE_THRESHOLD_SECONDS:
+            return
+        _LOGGER.warning(
+            "Vimar watchdog tripped (thread_alive=%s, stale=%.0fs); reconnecting",
+            alive,
+            stale_seconds,
+        )
+        await self.hass.async_add_executor_job(self.client.reconnect)
 
     def _get_gateway_info(self, user_input: dict[str, str]) -> GatewayInfo:
         return GatewayInfo(

--- a/custom_components/vimar_byme_plus/services.yaml
+++ b/custom_components/vimar_byme_plus/services.yaml
@@ -1,0 +1,8 @@
+restart:
+  fields:
+    entry_id:
+      required: false
+      example: "01H3X7Q8E5W..."
+      selector:
+        config_entry:
+          integration: vimar_byme_plus

--- a/custom_components/vimar_byme_plus/strings.json
+++ b/custom_components/vimar_byme_plus/strings.json
@@ -33,5 +33,17 @@
         "description": "Please enter your Setup Code obtained from Vimar Pro app.\nRefer to the official documentation for additional info [here]({url_documentation})"
       }
     }
+  },
+  "services": {
+    "restart": {
+      "name": "Restart integration",
+      "description": "Reload the VIMAR By-me Plus HUB integration. Useful from automations to recover from a stuck connection.",
+      "fields": {
+        "entry_id": {
+          "name": "Gateway",
+          "description": "Optional config entry to reload. Leave empty to reload every configured Vimar gateway."
+        }
+      }
+    }
   }
 }

--- a/custom_components/vimar_byme_plus/translations/en.json
+++ b/custom_components/vimar_byme_plus/translations/en.json
@@ -33,5 +33,17 @@
                 "description": "Use the Discovery for a easier setup or fill the following values.\nRefer to the official documentation for additional info [here]({url_documentation})"
             }
         }
+    },
+    "services": {
+        "restart": {
+            "name": "Restart integration",
+            "description": "Reload the VIMAR By-me Plus HUB integration. Useful from automations to recover from a stuck connection.",
+            "fields": {
+                "entry_id": {
+                    "name": "Gateway",
+                    "description": "Optional config entry to reload. Leave empty to reload every configured Vimar gateway."
+                }
+            }
+        }
     }
 }

--- a/custom_components/vimar_byme_plus/translations/it.json
+++ b/custom_components/vimar_byme_plus/translations/it.json
@@ -33,5 +33,17 @@
                 "description": "[%key:common::config_flow::description::confirm_setup%]"
             }
         }
+    },
+    "services": {
+        "restart": {
+            "name": "Riavvia integrazione",
+            "description": "Ricarica l'integrazione VIMAR By-me Plus HUB. Utile da automation per recuperare da una connessione bloccata.",
+            "fields": {
+                "entry_id": {
+                    "name": "Gateway",
+                    "description": "Config entry da ricaricare (opzionale). Lasciare vuoto per ricaricare tutti i gateway Vimar configurati."
+                }
+            }
+        }
     }
 }

--- a/custom_components/vimar_byme_plus/vimar/client/vimar_client.py
+++ b/custom_components/vimar_byme_plus/vimar/client/vimar_client.py
@@ -13,6 +13,7 @@ from ..service.association_service import AssociationService
 from ..service.operational_service import OperationalService, Update
 from ..utils.logger import log_info
 from ..utils.thread import Thread
+from ..utils.thread_monitor import thread_exists
 
 
 class VimarClient:
@@ -47,6 +48,28 @@ class VimarClient:
             daemon=True,
         )
         thread.start()
+
+    def reconnect(self):
+        """Force a tear-down and a fresh connect.
+
+        Used by the HA watchdog when the daemon thread has died or the
+        gateway has gone silent. Disconnect best-effort, then re-enter
+        operational_phase to spawn a new VimarServiceThread.
+        """
+        try:
+            self._operational_service.disconnect()
+        except Exception:  # pylint: disable=broad-except
+            log_info(__name__, "Disconnect raised; ignoring and re-attaching.")
+        self.operational_phase()
+
+    def is_thread_alive(self) -> bool:
+        """Return True if the Vimar service daemon thread is running."""
+        return thread_exists(self._thread_name)
+
+    @property
+    def seconds_since_last_message(self) -> float:
+        """Seconds since the gateway last sent any message."""
+        return self._operational_service.seconds_since_last_message
 
     def send(self, component: VimarComponent, action_type: ActionType, *args):
         """Send a request coming from HomeAssistant to Gateway."""

--- a/custom_components/vimar_byme_plus/vimar/client/web_service/sync_base_socket.py
+++ b/custom_components/vimar_byme_plus/vimar/client/web_service/sync_base_socket.py
@@ -15,6 +15,13 @@ from ...service.handler.message_handler.message_handler import MessageHandler
 from ...utils.logger import log_debug, log_info
 from ...utils.session_token import get_session_token
 
+# Generous network timeouts: connect() and recv() must not block the
+# daemon thread forever if the gateway becomes unresponsive mid-handshake
+# or mid-transaction. Errors raised here are caught upstream by the
+# bounded retry loop in OperationalService.connect().
+_CONNECT_TIMEOUT_SECONDS = 30
+_RECV_TIMEOUT_SECONDS = 60
+
 
 class SyncBaseSocket:
     """Web Socket Session Phase Class."""
@@ -38,7 +45,11 @@ class SyncBaseSocket:
         """Create WebSocket connection."""
         log_info(__name__, f"Connecting to {url}...")
         ssl_opt = self._get_ssl_options()
-        return create_connection(url, sslopt=ssl_opt)
+        ws = create_connection(
+            url, sslopt=ssl_opt, timeout=_CONNECT_TIMEOUT_SECONDS
+        )
+        ws.settimeout(_RECV_TIMEOUT_SECONDS)
+        return ws
 
     def send(self, message: BaseRequestResponse):
         """Send BaseRequestResponse object."""

--- a/custom_components/vimar_byme_plus/vimar/client/web_service/ws_attach_phase.py
+++ b/custom_components/vimar_byme_plus/vimar/client/web_service/ws_attach_phase.py
@@ -3,10 +3,20 @@ from websocket._app import WebSocketApp
 from ...model.web_socket.base_request_response import BaseRequestResponse
 from ...model.web_socket.base_response import BaseResponse
 from ...model.web_socket.web_socket_config import WebSocketConfig
+from ...utils.logger import log_error
 from .ws_base_vimar import WebSocketBaseVimar
 
 
 class WSAttachPhase(WebSocketBaseVimar):
+    """Attach-phase WebSocket wrapper.
+
+    The four `on_*` callbacks are invoked from the websocket-client
+    daemon thread (`run_forever`). Any uncaught exception there bubbles
+    up and tears the thread down, leaving the integration silently
+    disconnected. Each callback below catches and logs Exception so a
+    single buggy handler can't kill the whole connection.
+    """
+
     _config: WebSocketConfig
 
     def __init__(self, config: WebSocketConfig):
@@ -14,36 +24,47 @@ class WSAttachPhase(WebSocketBaseVimar):
         self._config = config
 
     def on_open(self, ws: WebSocketApp):
-        if self._config.on_open_callback:
-            self._config.on_open_callback()
-
-        session_response = self.get_mock_session_response()
-        self.on_message(ws, message=session_response)
+        try:
+            if self._config.on_open_callback:
+                self._config.on_open_callback()
+            session_response = self.get_mock_session_response()
+            self.on_message(ws, message=session_response)
+        except Exception as exc:  # pylint: disable=broad-except
+            log_error(__name__, f"on_open raised: {exc!r}")
 
     def on_close(self, ws: WebSocketApp):
-        callback = self._config.on_close_callback
-        if callback:
-            callback(self.last_server_message)
+        try:
+            callback = self._config.on_close_callback
+            if callback:
+                callback(self.last_server_message)
+        except Exception as exc:  # pylint: disable=broad-except
+            log_error(__name__, f"on_close raised: {exc!r}")
 
     def on_message(self, ws: WebSocketApp, message: BaseRequestResponse):
-        callback = self._config.on_message_callback
-        if callback:
-            request = callback(message)
-            if message.function == "expire":
-                ws.close()
-            if request:
-                self.send(request)
+        try:
+            callback = self._config.on_message_callback
+            if callback:
+                request = callback(message)
+                if message.function == "expire":
+                    ws.close()
+                if request:
+                    self.send(request)
+        except Exception as exc:  # pylint: disable=broad-except
+            log_error(__name__, f"on_message raised: {exc!r}")
 
     def on_error(self, ws: WebSocketApp, exception: Exception):
-        callback = self._config.on_error_message_callback
-        if callback:
-            request = callback(
-                self.last_client_message, self.last_server_message, exception
-            )
-            if request:
-                self.send(request)
-            else:
-                ws.close()
+        try:
+            callback = self._config.on_error_message_callback
+            if callback:
+                request = callback(
+                    self.last_client_message, self.last_server_message, exception
+                )
+                if request:
+                    self.send(request)
+                else:
+                    ws.close()
+        except Exception as exc:  # pylint: disable=broad-except
+            log_error(__name__, f"on_error raised: {exc!r}")
 
     def get_mock_session_response(self) -> BaseResponse:
         return BaseResponse(function="session", msgid=0)

--- a/custom_components/vimar_byme_plus/vimar/scheduler/keep_alive_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/scheduler/keep_alive_handler.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 import threading
 
+from ..utils.logger import log_error
 from ..utils.thread import Timer
 
 
@@ -22,8 +23,14 @@ class KeepAliveHandler:
             self._timer.start()
 
     def _execute(self):
-        if self._callback:
-            self._callback()
+        # Never let a callback exception kill the keep-alive timer: the
+        # next tick must still be scheduled, otherwise the WS goes silent
+        # without anyone noticing.
+        try:
+            if self._callback:
+                self._callback()
+        except Exception as exc:  # pylint: disable=broad-except
+            log_error(__name__, f"Keep-alive callback raised: {exc!r}")
         self._start_timer()
 
     def reset(self):

--- a/custom_components/vimar_byme_plus/vimar/service/operational_service.py
+++ b/custom_components/vimar_byme_plus/vimar/service/operational_service.py
@@ -16,12 +16,23 @@ from ..model.web_socket.base_request import BaseRequest
 from ..model.web_socket.base_request_response import BaseRequestResponse
 from ..model.web_socket.web_socket_config import WebSocketConfig
 from ..scheduler.keep_alive_handler import KeepAliveHandler
-from ..utils.logger import log_info, log_debug
+from ..utils.logger import log_debug, log_error, log_info
 from .handler.action_handler.action_handler import ActionHandler
 from .handler.error_handler.error_handler import ErrorHandler
 from .handler.message_handler.message_handler import MessageHandler
 
 type Update = Coroutine[Any, Any, None]
+
+# Bounded reconnect loop. Cap backoff at 600s to avoid stack growth and
+# unbounded re-tries when the gateway is unreachable for hours; after
+# `_MAX_CONNECT_ATTEMPTS` consecutive failures we let the exception
+# propagate — the HA-side watchdog (Coordinator) will resume from there
+# at its next tick.
+_MAX_CONNECT_ATTEMPTS = 5
+_BACKOFF_BASE_SECONDS = 60
+_BACKOFF_CAP_SECONDS = 600
+
+_DEFAULT_RECONNECT_WAIT_SECONDS = 60
 
 
 class OperationalService:
@@ -50,20 +61,57 @@ class OperationalService:
         self._error_handler = ErrorHandler(gateway_info)
         self._message_handler = MessageHandler(gateway_info)
         self._keep_alive_handler = KeepAliveHandler()
+        # Watchdog timestamp: monotonic seconds of the last activity from
+        # the gateway. The HA-side Coordinator polls this to detect
+        # silent-stale state (TCP up but no messages flowing).
+        self._last_message_at: float = time.monotonic()
+
+    @property
+    def last_message_at(self) -> float:
+        """Monotonic timestamp (seconds) of the last gateway activity."""
+        return self._last_message_at
+
+    @property
+    def seconds_since_last_message(self) -> float:
+        return time.monotonic() - self._last_message_at
+
+    def _touch_last_message(self) -> None:
+        self._last_message_at = time.monotonic()
 
     def connect(self):
-        """Handle the connection Vimar WebSocket connection."""
-        try:
-            self.clean()
-            self.sync_session_phase()
-            self.async_attach_phase()
-        except Exception as exc:
-            if self._error_handler.is_temporary_error(exception=exc):
-                log_info(__name__, "Waiting 60 seconds before reconnecting...")
-                time.sleep(60)
-                self.connect()
-            else:
-                raise VimarErrorResponseException(exc) from exc
+        """Connect to the gateway with bounded retry and exponential backoff.
+
+        Replaces the previous unbounded recursive retry. After
+        `_MAX_CONNECT_ATTEMPTS` consecutive failures the last exception is
+        raised so the daemon thread exits cleanly; the watchdog will
+        re-enter from the next tick.
+        """
+        for attempt in range(_MAX_CONNECT_ATTEMPTS):
+            try:
+                self.clean()
+                self.sync_session_phase()
+                self.async_attach_phase()
+                self._touch_last_message()
+                return
+            except Exception as exc:
+                if not self._error_handler.is_temporary_error(exception=exc):
+                    raise VimarErrorResponseException(exc) from exc
+                wait = min(
+                    _BACKOFF_BASE_SECONDS * (2 ** attempt),
+                    _BACKOFF_CAP_SECONDS,
+                )
+                log_info(
+                    __name__,
+                    f"Temporary connection error (attempt {attempt + 1}"
+                    f"/{_MAX_CONNECT_ATTEMPTS}); retrying in {wait}s...",
+                )
+                time.sleep(wait)
+        log_error(
+            __name__,
+            f"Connection failed after {_MAX_CONNECT_ATTEMPTS} attempts; "
+            "yielding to watchdog.",
+        )
+        raise VimarErrorResponseException("Connection retry budget exhausted")
 
     def send_action(self, component: VimarComponent, action_type: ActionType, *args):
         """Send a request coming from HomeAssistant to Gateway."""
@@ -106,10 +154,12 @@ class OperationalService:
     def on_attach_connection_opened(self):
         self._keep_alive_handler = KeepAliveHandler()
         self._keep_alive_handler.set_handler(self.send_keep_alive)
+        self._touch_last_message()
 
     def on_attach_message_received(
         self, message: BaseRequestResponse
     ) -> BaseRequestResponse:
+        self._touch_last_message()
         response = self._message_handler.message_received(message)
         self.trigger_changes(message)
         self.handle_keep_alive(response)
@@ -132,10 +182,13 @@ class OperationalService:
         self.attach_port = None
         if isinstance(message, BaseRequest):
             seconds_to_wait = self._get_seconds_to_wait(message)
-            message = f"Waiting {seconds_to_wait!s} seconds before reconnecting..."
-            log_info(__name__, message)
+            log_info(
+                __name__,
+                f"Waiting {seconds_to_wait}s before reconnecting...",
+            )
             time.sleep(seconds_to_wait)
             self.connect()
+            return
         if self._error_handler.is_temporary_error(None, message):
             log_info(__name__, "Temporary Error detected, reconnecting...")
             self.connect()
@@ -178,9 +231,19 @@ class OperationalService:
         return config
 
     def _get_seconds_to_wait(self, request: BaseRequest) -> int:
+        """Extract the gateway-suggested reconnect delay.
+
+        Falls back to a sensible default when the gateway sends an empty
+        args payload — the previous behaviour silently disconnected the
+        socket and returned None, causing `time.sleep(None)` to crash the
+        thread.
+        """
         if request and request.args:
-            return int(request.args[0].get("value", 0))
-        self.disconnect()
+            try:
+                return int(request.args[0].get("value", 0))
+            except (TypeError, ValueError):
+                return _DEFAULT_RECONNECT_WAIT_SECONDS
+        return _DEFAULT_RECONNECT_WAIT_SECONDS
 
     def disconnect(self):
         log_info(__name__, "Terminating the execution...")


### PR DESCRIPTION
## Summary

Closes #33.

The integration sometimes gets stuck in a state where the WebSocket appears connected but no events flow, requiring a manual HA restart.
The previous error handler caught only a narrow set of exceptions and the WebSocket callbacks ran without any safety net, so a single bug or a silent gateway could silently kill the daemon thread with no visible warning.

This PR makes the integration self-healing first, and adds a manual restart action as a backstop.

## What changed

### Self-healing (Coordinator watchdog)

- New `Coordinator` watchdog scheduled every 5 minutes via `async_track_time_interval`. Two checks per tick:
  - Is the `VimarServiceThread` daemon alive?
  - `seconds_since_last_message < 300`?
  - If either fails, the watchdog forces `client.reconnect()` (run in an executor since it's blocking).
- New `OperationalService.last_message_at` (monotonic) updated on connection-opened and on every received message; exposed up the stack through `VimarClient.seconds_since_last_message`.

### Hardening

- All four `WSAttachPhase` callbacks (`on_open`, `on_close`, `on_message`, `on_error`) wrapped in `try/except Exception` with logging.
- `KeepAliveHandler._execute` catches callback exceptions and **always** reschedules the timer.
- `SyncBaseSocket._create_connection` now sets a 30s connect timeout and a 60s recv timeout (`ws.settimeout(60)`).
- `OperationalService.connect()` rewritten from unbounded recursion to a bounded loop (`max_attempts=5`) with exponential backoff (60s → 120s → 240s → 480s → 600s cap). After exhaustion it raises and yields to the watchdog instead of growing the call stack forever.
- `_get_seconds_to_wait` now falls back to a sane default (60s) when the gateway sends an empty `args` payload, fixing the `time.sleep(None) → TypeError` crash.

### Manual restart action (issue's literal request)

- New `vimar_byme_plus.restart` service registered idempotently in `async_setup_entry`. Optional `entry_id` field reloads a single gateway; without it, every Vimar entry is reloaded. Documented in `services.yaml` with a `config_entry` selector so the UI dropdown only shows Vimar entries.