### PR TITLE
Energy Sensors slow update

### DIFF
--- a/custom_components/vimar_byme_plus/vimar/mapper/energy/ss_energy_load_control_1p_production_mapper.py
+++ b/custom_components/vimar_byme_plus/vimar/mapper/energy/ss_energy_load_control_1p_production_mapper.py
@@ -26,7 +26,7 @@ CONSUMPTION = SfeType.STATE_GLOBAL_ACTIVE_POWER_CONSUMPTION
 class SsEnergyLoadControl1pProductionMapper(SsEnergyLoadControl1pMapper):
     SSTYPE = SsType.ENERGY_LOAD_CONTROL_1P_PRODUCTION.value
 
-    def from_obj(self, component: UserComponent, *args) -> list[VimarSensor]:
+    def from_obj(self, component: UserComponent, *args) -> list:
         return [
             self.power_from_obj(component, "Exchange"),
             self.energy_from_obj(component, "Exchange"),
@@ -34,6 +34,7 @@ class SsEnergyLoadControl1pProductionMapper(SsEnergyLoadControl1pMapper):
             self.energy_from_obj(component, "Production"),
             self.power_from_obj(component, "Consumption"),
             self.energy_from_obj(component, "Consumption"),
+            self.real_time_button(component, *args),
         ]
 
     def power_from_obj(self, component: UserComponent, mode: str) -> VimarSensor:

--- a/custom_components/vimar_byme_plus/vimar/mapper/energy/ss_energy_measure_1p_mapper.py
+++ b/custom_components/vimar_byme_plus/vimar/mapper/energy/ss_energy_measure_1p_mapper.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from decimal import ROUND_HALF_UP, Decimal
 
+from ...model.component.vimar_button import VimarButton
 from ...model.component.vimar_sensor import (
     SensorDeviceClass,
     SensorMeasurementUnit,
@@ -16,10 +17,11 @@ from ..base_mapper import BaseMapper
 class SsEnergyMeasure1pMapper(BaseMapper):
     SSTYPE = SsType.ENERGY_MEASURE_1P.value
 
-    def from_obj(self, component: UserComponent, *args) -> list[VimarSensor]:
+    def from_obj(self, component: UserComponent, *args) -> list:
         return [
             self.power_from_obj(component, *args),
             self.energy_from_obj(component, *args),
+            self.real_time_button(component, *args),
         ]
 
     def power_from_obj(self, component: UserComponent, *args) -> VimarSensor:
@@ -54,6 +56,18 @@ class SsEnergyMeasure1pMapper(BaseMapper):
             unit_of_measurement=SensorMeasurementUnit.KILO_WATT_HOUR,
             state_class=SensorStateClass.TOTAL_INCREASING,
             options=None,
+        )
+
+    def real_time_button(self, component: UserComponent, *args) -> VimarButton:
+        return VimarButton(
+            id=str(component.idsf) + "_real_time_updates",
+            name=component.name + " - " + "Aggiornamenti RealTime",
+            device_group=component.sftype,
+            device_name=component.sstype,
+            device_class=None,
+            area=component.ambient.name,
+            main_id=component.idsf,
+            executed=False,
         )
 
     def native_value(self, component: UserComponent) -> Decimal | None:

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/action_handler.py
@@ -7,6 +7,7 @@ from .audio.audio_action_handler import AudioActionHandler
 from .automation.automation_action_handler import AutomationActionHandler
 from .base_action_handler import BaseActionHandler
 from .clima.clima_action_handler import ClimaActionHandler
+from .energy.energy_action_handler import EnergyActionHandler
 from .irrigation.irrigation_action_handler import IrrigationActionHandler
 from .light.light_action_handler import LightActionHandler
 from .scene.scene_action_handler import SceneActionHandler
@@ -34,6 +35,8 @@ class ActionHandler:
                 return AutomationActionHandler()
             case SfType.CLIMA:
                 return ClimaActionHandler()
+            case SfType.ENERGY:
+                return EnergyActionHandler()
             case SfType.IRRIGATION:
                 return IrrigationActionHandler()
             case SfType.LIGHT:

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/energy/energy_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/energy/energy_action_handler.py
@@ -1,0 +1,25 @@
+from .....model.component.vimar_action import VimarAction
+from .....model.component.vimar_button import VimarButton
+from .....model.component.vimar_component import VimarComponent
+from .....model.enum.action_type import ActionType
+from .....model.enum.sfetype_enum import SfeType
+
+REAL_TIME = SfeType.CMD_TIMED_DYNAMIC_MODE
+
+
+class EnergyActionHandler:
+    def get_actions(
+        self, component: VimarComponent, action_type: ActionType, *args
+    ) -> list[VimarAction]:
+        if action_type == ActionType.PRESS:
+            return self.get_press_actions(component)
+        raise NotImplementedError
+
+    def get_press_actions(self, component: VimarButton) -> list[VimarAction]:
+        if "real_time" in component.id:
+            return [
+                VimarAction(
+                    idsf=component.main_id, sfetype=REAL_TIME.value, value="Start"
+                )
+            ]
+        raise NotImplementedError


### PR DESCRIPTION
## Summary

Closes #29.

Power readings of energy sensors update very slowly under normal operation, and only become responsive while the Vimar View app is open on a phone. The Vimar View app keeps power meters fresh by sending `SFE_Cmd_TimedDynamicMode` to the gateway, a command that temporarily raises the broker's measurement push frequency. 
The integration already exposes that command as an "Aggiornamenti RealTime" button on generic sensors, but the energy sensors button were missing and there was no way to trigger real-time mode from Home Assistant.

## Why

Three findings in the existing code:

1. **The real-time button mechanism already exists** for sensors that inherit from `SsSensorGenericMapper`: `from_obj` creates a `VimarButton` with `id = <idsf>_real_time_updates`, and `SensorActionHandler.get_press_actions` translates a press into `SFE_Cmd_TimedDynamicMode = "Start"`.
2. **The energy mappers don't inherit from it**, so no button is ever created for `SS_Energy_LoadControl1P/3P`, `SS_Energy_Measure1P/3P` or their `Production` variants — exactly the device classes the 01455 generates.
3. **`ActionHandler._get_handler` has no `SF_Energy` case**, so even if we created the button, pressing it would `raise NotImplementedError`.

## What changed

Three small additions, mirroring the existing sensor pattern:

### 1. New `EnergyActionHandler`

`vimar/service/handler/action_handler/energy/energy_action_handler.py` (new), plus an empty `__init__.py`. Same shape as `SensorActionHandler`: when the pressed component's id contains `"real_time"` and the action type is `PRESS`, it emits `VimarAction(idsf=component.main_id, sfetype=SFE_Cmd_TimedDynamicMode, value="Start")`.

### 2. Dispatcher route

`ActionHandler._get_handler` in `vimar/service/handler/action_handler/action_handler.py` now has a `SfType.ENERGY → EnergyActionHandler()` case, alongside the existing ones.

### 3. "Aggiornamenti RealTime" button on energy mappers

- `vimar/mapper/energy/ss_energy_measure_1p_mapper.py`: `from_obj` returns a third element, a `VimarButton` with `id = <idsf>_real_time_updates` and `main_id = <idsf>`. By inheritance this also covers `Measure3p`, `LoadControl1p`, and `LoadControl3p`.
- `vimar/mapper/energy/ss_energy_load_control_1p_production_mapper.py`: same button appended in its `from_obj`, since this class fully overrides the parent. By inheritance this also covers `LoadControl3pProduction`.

`SsEnergyMeasureCounterMapper` and `SsEnergyLoadMapper` are left untouched: per the spec they don't support `TimedDynamicMode`.
