### PR TITLE
OptionsFlow implementation for user preferences

### DIFF
--- a/custom_components/vimar_byme_plus/__init__.py
+++ b/custom_components/vimar_byme_plus/__init__.py
@@ -26,10 +26,11 @@ type CoordinatorConfigEntry = ConfigEntry[Coordinator]
 
 async def async_setup_entry(hass: HomeAssistant, entry: CoordinatorConfigEntry) -> bool:
     """Set up Hello World from a config entry."""
-    coordinator = Coordinator(hass, entry.data)
+    coordinator = Coordinator(hass, entry.data, entry)
     await coordinator.async_config_entry_first_refresh()
     await start(coordinator)
     entry.runtime_data = coordinator
+    entry.async_on_unload(entry.add_update_listener(_async_options_updated))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
@@ -43,6 +44,13 @@ async def async_unload_entry(
         entry.runtime_data.stop()
     entry.runtime_data = None
     return unload_ok
+
+
+async def _async_options_updated(
+    hass: HomeAssistant, entry: CoordinatorConfigEntry
+) -> None:
+    """Reload integration when options change."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def start(coordinator: Coordinator):

--- a/custom_components/vimar_byme_plus/config_flow.py
+++ b/custom_components/vimar_byme_plus/config_flow.py
@@ -8,7 +8,8 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
-from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
+from homeassistant.core import callback
 
 from .const import (
     ADDRESS,
@@ -23,6 +24,7 @@ from .const import (
     PROTOCOL,
 )
 from .coordinator import Coordinator
+from .options import SECTIONS, OptionsSection
 from .vimar.model.exceptions import CodeNotValidException, VimarErrorResponseException
 from .vimar.utils.logger import log_debug, log_error
 
@@ -46,6 +48,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> "OptionsFlowHandler":
+        """Return the options flow handler."""
+        return OptionsFlowHandler(config_entry)
 
     async def async_step_user(self, user_input=None) -> ConfigFlowResult:
         """Handle the user manual setup."""
@@ -169,3 +179,68 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             GATEWAY_NAME: user_input[GATEWAY_NAME],
             PROTOCOL: "2.7",
         }
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Generic, section-driven options flow.
+
+    Composed of independent `OptionsSection`s declared in the `options/`
+    package. The flow:
+      - filters sections by `is_applicable(hass)`,
+      - aborts with `nothing_to_configure` if none are applicable,
+      - shortcuts directly to the only applicable section,
+      - shows a menu (`async_show_menu`) when more than one is applicable.
+
+    Each section persists its data under `entry.options[section.id]`.
+    Adding a new section: see `options/base.py` docstring.
+    """
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        self._entry = config_entry
+        self._sections: dict[str, OptionsSection] = {
+            cls.id: cls() for cls in SECTIONS
+        }
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        applicable = [
+            sid
+            for sid, section in self._sections.items()
+            if await section.is_applicable(self.hass)
+        ]
+        if not applicable:
+            return self.async_abort(reason="nothing_to_configure")
+        if len(applicable) == 1:
+            return await self._render_section(applicable[0], user_input=None)
+        return self.async_show_menu(step_id="init", menu_options=applicable)
+
+    # --- per-section step methods -------------------------------------
+    # Each section needs its own async_step_<id> for HA's flow manager.
+    # Adding a new section: copy the pattern below.
+
+    async def async_step_counters(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        return await self._render_section("counters", user_input)
+
+    # ------------------------------------------------------------------
+
+    async def _render_section(
+        self,
+        section_id: str,
+        user_input: dict[str, Any] | None,
+    ) -> ConfigFlowResult:
+        section = self._sections[section_id]
+        if user_input is not None:
+            data = await section.transform_user_input(self.hass, user_input)
+            options = {**self._entry.options, section_id: data}
+            return self.async_create_entry(title="", data=options)
+        current = self._entry.options.get(section_id, {})
+        schema = await section.build_schema(self.hass, current)
+        placeholders = await section.description_placeholders(self.hass)
+        return self.async_show_form(
+            step_id=section_id,
+            data_schema=schema,
+            description_placeholders=placeholders,
+        )

--- a/custom_components/vimar_byme_plus/const.py
+++ b/custom_components/vimar_byme_plus/const.py
@@ -23,3 +23,11 @@ DOCUMENTATION_URL = (
     "https://github.com/andreaprosseda/vimar-byme-plus-homeassistant"
     "?tab=readme-ov-file#step-23-vimar-pro---initial-setup"
 )
+
+# OptionsFlow section ids (each is a sub-key under entry.options)
+SECTION_COUNTERS: Final = "counters"
+
+# Counter kinds (values stored under entry.options[SECTION_COUNTERS])
+COUNTER_ELECTRICITY: Final = "electricity"
+COUNTER_WATER: Final = "water"
+COUNTER_GAS: Final = "gas"

--- a/custom_components/vimar_byme_plus/coordinator.py
+++ b/custom_components/vimar_byme_plus/coordinator.py
@@ -4,15 +4,27 @@ import logging
 
 from websocket import WebSocketConnectionClosedException
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import ADDRESS, CODE, DOMAIN, GATEWAY_ID, GATEWAY_NAME, HOST, PORT, PROTOCOL
+from .const import (
+    ADDRESS,
+    CODE,
+    DOMAIN,
+    GATEWAY_ID,
+    GATEWAY_NAME,
+    HOST,
+    PORT,
+    PROTOCOL,
+    SECTION_COUNTERS,
+)
 from .vimar.client.vimar_client import VimarClient
 from .vimar.model.component.vimar_component import VimarComponent
 from .vimar.model.enum.action_type import ActionType
 from .vimar.model.gateway.gateway_info import GatewayInfo
 from .vimar.model.gateway.vimar_data import VimarData
+from .vimar.model.integration_options import IntegrationOptions
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,13 +35,26 @@ class Coordinator(DataUpdateCoordinator[VimarData]):
     gateway_info: GatewayInfo
     client: VimarClient
 
-    def __init__(self, hass: HomeAssistant, user_input: dict[str, str]) -> None:
+    def __init__(
+        self, hass: HomeAssistant, user_input: dict[str, str], entry: ConfigEntry | None = None
+    ) -> None:
         """Initialize the coordinator."""
+        self._entry = entry
         self.gateway_info = self._get_gateway_info(user_input)
         self.client = VimarClient(self.gateway_info, self.update_data)
         self.client.set_setup_code(user_input.get(CODE))
 
         super().__init__(hass, _LOGGER, name=DOMAIN)
+
+    @property
+    def options(self) -> IntegrationOptions:
+        """Materialise entry.options into the runtime options bundle."""
+        if self._entry is None:
+            return IntegrationOptions()
+        raw = self._entry.options or {}
+        return IntegrationOptions(
+            counter_types=raw.get(SECTION_COUNTERS, {}) or {},
+        )
 
     def associate(self):
         """Test coordinator processes."""
@@ -57,11 +82,11 @@ class Coordinator(DataUpdateCoordinator[VimarData]):
 
     @callback
     def _update_data(self):
-        data = self.client.retrieve_data()
+        data = self.client.retrieve_data(self.options)
         self.async_set_updated_data(data)
 
     async def _async_update_data(self) -> VimarData:
-        return self.client.retrieve_data()
+        return self.client.retrieve_data(self.options)
 
     def _get_gateway_info(self, user_input: dict[str, str]) -> GatewayInfo:
         return GatewayInfo(

--- a/custom_components/vimar_byme_plus/options/__init__.py
+++ b/custom_components/vimar_byme_plus/options/__init__.py
@@ -1,0 +1,8 @@
+"""Section registry for the OptionsFlow."""
+
+from .base import OptionsSection
+from .counters import CountersSection
+
+SECTIONS: tuple[type[OptionsSection], ...] = (CountersSection,)
+
+__all__ = ["OptionsSection", "SECTIONS"]

--- a/custom_components/vimar_byme_plus/options/base.py
+++ b/custom_components/vimar_byme_plus/options/base.py
@@ -1,0 +1,52 @@
+"""Base abstraction for OptionsFlow sections.
+
+Each section is an independent unit of configuration with its own form,
+storage slot in `entry.options`, and applicability predicate. Sections are
+composed by the OptionsFlow at runtime: only those whose `is_applicable`
+returns True are exposed to the user.
+
+Adding a new section requires:
+  1. a subclass of `OptionsSection` in this package,
+  2. registration in `options/__init__.py` (`SECTIONS` tuple),
+  3. an `async_step_<section_id>` method on `OptionsFlowHandler`
+     delegating to `_handle_section_step`,
+  4. translation entries under `options.step.<section_id>` and a label
+     under `options.step.init.menu_options.<section_id>`.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant
+
+
+class OptionsSection(ABC):
+    """A configurable section in the OptionsFlow."""
+
+    id: str  # unique id, also key under entry.options
+
+    @abstractmethod
+    async def is_applicable(self, hass: HomeAssistant) -> bool:
+        """Return True if this section has anything to configure right now."""
+
+    @abstractmethod
+    async def build_schema(
+        self, hass: HomeAssistant, current: dict[str, Any]
+    ) -> vol.Schema:
+        """Return the form schema, pre-populated with current values."""
+
+    async def description_placeholders(
+        self, hass: HomeAssistant
+    ) -> dict[str, str] | None:
+        """Optional description placeholders shown in the form's text."""
+        return None
+
+    async def transform_user_input(
+        self, hass: HomeAssistant, user_input: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Optional hook to post-process user input before persisting."""
+        return user_input

--- a/custom_components/vimar_byme_plus/options/counters.py
+++ b/custom_components/vimar_byme_plus/options/counters.py
@@ -1,0 +1,84 @@
+"""OptionsFlow section: per-device kind for SS_Energy_MeasureCounter (01452).
+
+Lets the user pick electricity / water / gas for each Vimar 01452 pulse
+counter so the integration applies the right device_class / unit /
+value scaling.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
+
+from ..const import (
+    COUNTER_ELECTRICITY,
+    COUNTER_GAS,
+    COUNTER_WATER,
+    SECTION_COUNTERS,
+)
+from ..vimar.database.database import Database
+from ..vimar.model.enum.sstype_enum import SsType
+from .base import OptionsSection
+
+
+class CountersSection(OptionsSection):
+    """Counter type picker per pulse-counter device."""
+
+    id = SECTION_COUNTERS
+
+    async def is_applicable(self, hass: HomeAssistant) -> bool:
+        counters = await hass.async_add_executor_job(self._get_counters)
+        return bool(counters)
+
+    async def build_schema(
+        self, hass: HomeAssistant, current: dict[str, Any]
+    ) -> vol.Schema:
+        counters = await hass.async_add_executor_job(self._get_counters)
+        select = SelectSelector(
+            SelectSelectorConfig(
+                options=[COUNTER_ELECTRICITY, COUNTER_WATER, COUNTER_GAS],
+                translation_key="counter_type",
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        )
+        return vol.Schema(
+            {
+                vol.Required(
+                    str(idsf),
+                    description={
+                        "suggested_value": current.get(
+                            str(idsf), COUNTER_ELECTRICITY
+                        )
+                    },
+                    default=COUNTER_ELECTRICITY,
+                ): select
+                for idsf, _name in counters
+            }
+        )
+
+    async def description_placeholders(
+        self, hass: HomeAssistant
+    ) -> dict[str, str]:
+        counters = await hass.async_add_executor_job(self._get_counters)
+        return {
+            "counters": ", ".join(
+                f"{name} (#{idsf})" for idsf, name in counters
+            )
+        }
+
+    @staticmethod
+    def _get_counters() -> list[tuple[int, str]]:
+        try:
+            components = Database.instance().component_repo.get_all()
+        except Exception:  # pylint: disable=broad-except
+            return []
+        sstype = SsType.ENERGY_MEASURE_COUNTER.value
+        return [(c.idsf, c.name) for c in components if c.sstype == sstype]

--- a/custom_components/vimar_byme_plus/strings.json
+++ b/custom_components/vimar_byme_plus/strings.json
@@ -33,5 +33,32 @@
         "description": "Please enter your Setup Code obtained from Vimar Pro app.\nRefer to the official documentation for additional info [here]({url_documentation})"
       }
     }
+  },
+  "options": {
+    "abort": {
+      "nothing_to_configure": "There is currently nothing to configure for this integration."
+    },
+    "step": {
+      "init": {
+        "title": "Configure VIMAR By-me Plus HUB",
+        "description": "Pick the section to configure.",
+        "menu_options": {
+          "counters": "Pulse counter type (01452)"
+        }
+      },
+      "counters": {
+        "title": "Pulse counter type (01452)",
+        "description": "For every Vimar 01452 pulse counter, pick the meter it is wired to (electricity / water / gas). Detected counters: {counters}"
+      }
+    }
+  },
+  "selector": {
+    "counter_type": {
+      "options": {
+        "electricity": "Electricity",
+        "water": "Water",
+        "gas": "Gas"
+      }
+    }
   }
 }

--- a/custom_components/vimar_byme_plus/translations/en.json
+++ b/custom_components/vimar_byme_plus/translations/en.json
@@ -33,5 +33,32 @@
                 "description": "Use the Discovery for a easier setup or fill the following values.\nRefer to the official documentation for additional info [here]({url_documentation})"
             }
         }
+    },
+    "options": {
+        "abort": {
+            "nothing_to_configure": "There is currently nothing to configure for this integration."
+        },
+        "step": {
+            "init": {
+                "title": "Configure VIMAR By-me Plus HUB",
+                "description": "Pick the section to configure.",
+                "menu_options": {
+                    "counters": "Pulse counter type (01452)"
+                }
+            },
+            "counters": {
+                "title": "Pulse counter type (01452)",
+                "description": "For every Vimar 01452 pulse counter, pick the meter it is wired to (electricity / water / gas). Detected counters: {counters}"
+            }
+        }
+    },
+    "selector": {
+        "counter_type": {
+            "options": {
+                "electricity": "Electricity",
+                "water": "Water",
+                "gas": "Gas"
+            }
+        }
     }
 }

--- a/custom_components/vimar_byme_plus/translations/it.json
+++ b/custom_components/vimar_byme_plus/translations/it.json
@@ -33,5 +33,32 @@
                 "description": "[%key:common::config_flow::description::confirm_setup%]"
             }
         }
+    },
+    "options": {
+        "abort": {
+            "nothing_to_configure": "Al momento non c'è nulla da configurare per questa integrazione."
+        },
+        "step": {
+            "init": {
+                "title": "Configura VIMAR By-me Plus HUB",
+                "description": "Scegli la sezione da configurare.",
+                "menu_options": {
+                    "counters": "Tipo pulse counter (01452)"
+                }
+            },
+            "counters": {
+                "title": "Tipo pulse counter (01452)",
+                "description": "Per ogni pulse counter Vimar 01452, seleziona il tipo di contatore a cui è cablato (elettricità / acqua / gas). Counter rilevati: {counters}"
+            }
+        }
+    },
+    "selector": {
+        "counter_type": {
+            "options": {
+                "electricity": "Elettricità",
+                "water": "Acqua",
+                "gas": "Gas"
+            }
+        }
     }
 }

--- a/custom_components/vimar_byme_plus/vimar/client/vimar_client.py
+++ b/custom_components/vimar_byme_plus/vimar/client/vimar_client.py
@@ -8,6 +8,7 @@ from ..model.enum.action_type import ActionType
 from ..model.exceptions import CodeNotValidException
 from ..model.gateway.gateway_info import GatewayInfo
 from ..model.gateway.vimar_data import VimarData
+from ..model.integration_options import IntegrationOptions
 from ..model.repository.user_credentials import UserCredentials
 from ..service.association_service import AssociationService
 from ..service.operational_service import OperationalService, Update
@@ -60,10 +61,12 @@ class VimarClient:
         """Stop coordinator processes."""
         self._operational_service.disconnect()
 
-    def retrieve_data(self) -> VimarData:
+    def retrieve_data(
+        self, options: IntegrationOptions | None = None
+    ) -> VimarData:
         """Get the latest data from DB."""
         components = self._component_repo.get_all()
-        return VimarDataMapper.from_list(components)
+        return VimarDataMapper.from_list(components, options or IntegrationOptions())
 
     def get_gateway_info(self) -> GatewayInfo:
         return self._operational_service.gateway_info

--- a/custom_components/vimar_byme_plus/vimar/mapper/energy/ss_energy_measure_counter_mapper.py
+++ b/custom_components/vimar_byme_plus/vimar/mapper/energy/ss_energy_measure_counter_mapper.py
@@ -3,40 +3,85 @@ from decimal import ROUND_HALF_UP, Decimal
 from ...model.component.vimar_sensor import (
     SensorDeviceClass,
     SensorMeasurementUnit,
+    SensorStateClass,
     VimarSensor,
 )
-from ...model.enum.sstype_enum import SsType
 from ...model.enum.sfetype_enum import SfeType
+from ...model.enum.sstype_enum import SsType
 from ...model.repository.user_component import UserComponent
 from ..base_mapper import BaseMapper
+
+# Per-type sensor configuration. Electricity preserves the historical
+# behaviour (kWh, /1000, no state_class) for users upgrading without
+# touching the new OptionsFlow. Water/Gas use TOTAL_INCREASING so they
+# show up in HA Energy/Statistics dashboards and the unit override sticks
+# (HA has unit converters for water/gas but not for energy<->litres).
+_ELECTRICITY_PROFILE = {
+    "device_class": SensorDeviceClass.ENERGY,
+    "unit": SensorMeasurementUnit.KILO_WATT_HOUR,
+    "divisor": 1000,
+    "state_class": None,
+    "decimal_precision": None,
+}
+
+_WATER_PROFILE = {
+    "device_class": SensorDeviceClass.WATER,
+    "unit": SensorMeasurementUnit.LITRE,
+    "divisor": 1,
+    "state_class": SensorStateClass.TOTAL_INCREASING,
+    "decimal_precision": 0,
+}
+
+_GAS_PROFILE = {
+    "device_class": SensorDeviceClass.GAS,
+    "unit": SensorMeasurementUnit.CUBIC_METERS,
+    "divisor": 1,
+    "state_class": SensorStateClass.TOTAL_INCREASING,
+    "decimal_precision": 0,
+}
+
+_PROFILES = {
+    "electricity": _ELECTRICITY_PROFILE,
+    "water": _WATER_PROFILE,
+    "gas": _GAS_PROFILE,
+}
 
 
 class SsEnergyMeasureCounterMapper(BaseMapper):
     SSTYPE = SsType.ENERGY_MEASURE_COUNTER.value
 
-    def from_obj(self, component: UserComponent, *args) -> list[VimarSensor]:
-        return [self._from_obj(component, *args)]
+    def from_obj(
+        self, component: UserComponent, counter_type: str | None = None, *args
+    ) -> list[VimarSensor]:
+        return [self._from_obj(component, counter_type)]
 
-    def _from_obj(self, component: UserComponent, *args) -> VimarSensor:
+    def _from_obj(
+        self, component: UserComponent, counter_type: str | None
+    ) -> VimarSensor:
+        profile = _PROFILES.get(counter_type or "electricity", _ELECTRICITY_PROFILE)
         return VimarSensor(
             id=str(component.idsf),
             name=component.name,
             device_group=component.sftype,
             device_name=component.sstype,
-            device_class=SensorDeviceClass.ENERGY,
+            device_class=profile["device_class"],
             area=component.ambient.name,
             main_id=component.idsf,
-            native_value=self.native_value(component),
+            native_value=self.native_value(component, profile["divisor"]),
             last_update=None,
-            decimal_precision=None,
-            unit_of_measurement=SensorMeasurementUnit.KILO_WATT_HOUR,
-            state_class=None,
+            decimal_precision=profile["decimal_precision"],
+            unit_of_measurement=profile["unit"],
+            state_class=profile["state_class"],
             options=None,
         )
 
-    def native_value(self, component: UserComponent) -> Decimal | None:
+    def native_value(
+        self, component: UserComponent, divisor: int
+    ) -> Decimal | None:
         value = component.get_value(SfeType.STATE_PARTIAL_COUNTER)
         if not value:
             return None
-        decimal_value = Decimal(value) / 1000
+        decimal_value = Decimal(value) / divisor
+        if divisor == 1:
+            return decimal_value
         return decimal_value.quantize(Decimal("0.001"), rounding=ROUND_HALF_UP)

--- a/custom_components/vimar_byme_plus/vimar/mapper/vimar_data_mapper.py
+++ b/custom_components/vimar_byme_plus/vimar/mapper/vimar_data_mapper.py
@@ -1,4 +1,5 @@
 from ..model.gateway.vimar_data import VimarData
+from ..model.integration_options import IntegrationOptions
 from ..model.repository.user_component import UserComponent
 from .access.access_mapper import AccessMapper
 from .audio.audio_mapper import AudioMapper
@@ -15,13 +16,17 @@ from .shutter.shutter_mapper import ShutterMapper
 
 class VimarDataMapper:
     @staticmethod
-    def from_list(components: list[UserComponent]) -> VimarData:
+    def from_list(
+        components: list[UserComponent],
+        options: IntegrationOptions | None = None,
+    ) -> VimarData:
+        opts = options or IntegrationOptions()
         vimar_components = []
         vimar_components.extend(AccessMapper.from_list(components))
         vimar_components.extend(AudioMapper.from_list(components))
         vimar_components.extend(AutomationMapper.from_list(components))
         vimar_components.extend(ClimaMapper.from_list(components))
-        vimar_components.extend(EnergyMapper.from_list(components))
+        vimar_components.extend(EnergyMapper.from_list(components, opts))
         vimar_components.extend(IrrigationMapper.from_list(components))
         vimar_components.extend(LightMapper.from_list(components))
         vimar_components.extend(SceneMapper.from_list(components))

--- a/custom_components/vimar_byme_plus/vimar/model/component/vimar_sensor.py
+++ b/custom_components/vimar_byme_plus/vimar/model/component/vimar_sensor.py
@@ -26,6 +26,7 @@ class SensorDeviceClass(StrEnum):
     TEMPERATURE = "temperature"
     VOLTAGE = "voltage"
     VOLUME_FLOW_RATE = "volume_flow_rate"
+    WATER = "water"
     WIND_SPEED = "wind_speed"
 
 
@@ -35,6 +36,7 @@ class SensorMeasurementUnit(StrEnum):
     CUBIC_METERS_PER_HOUR = "m³/h"
     KILO_WATT = "kW"
     KILO_WATT_HOUR = "kWh"
+    LITRE = "L"
     LITRE_PER_SQUARE_METER = "l/m²"
     LUX = "lx"
     METERS_PER_SECOND = "m/s"

--- a/custom_components/vimar_byme_plus/vimar/model/integration_options.py
+++ b/custom_components/vimar_byme_plus/vimar/model/integration_options.py
@@ -1,0 +1,17 @@
+"""Runtime options bundle flowing through the data pipeline.
+
+A single immutable container materialised by `Coordinator` from the HA
+`config_entry.options` and passed down `VimarClient.retrieve_data` →
+`VimarDataMapper` → individual mappers. Adding a new user-controlled
+option means: new field here, populate it in `Coordinator.options`, and
+read it from the consuming mapper. No signature changes downstream.
+"""
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class IntegrationOptions:
+    """Materialised values for every OptionsFlow section."""
+
+    counter_types: dict[str, str] = field(default_factory=dict)


### PR DESCRIPTION
## Summary

Closes #43.

The integration always exposed all entity sensors with `device_class=energy` and `unit=kWh` and divided the raw count by
1000. 

This PR makes the kind of meter behind each `SS_Energy_MeasureCounter` device user-configurable, and it ships the configuration UI as a small section-driven OptionsFlow framework so future per-device settings can be added without re-plumbing.

## Why

`SS_Energy_MeasureCounter` is a generic pulse counter. The Vimar protocol exposes only `SFE_State_PartialCounter` (a raw integer): there is no field telling the integration whether the pulses are coming from an electricity meter, a water meter, or a gas meter — that is decided by the installer when the counter is wired. The previous mapper hard-coded the electricity assumption, locking water/gas users out.

The fix has to ask the user. For that we need a per-device picker, an OptionsFlow page to host it, and a way for the picked value to flow all the way to the mapper that builds the sensor.

A generic, section-driven OptionsFlow is added

A new `options/` sub-package contains the OptionsFlow framework:

- `options/base.py` — abstract `OptionsSection` with `id`, `is_applicable(hass)`, `build_schema(hass, current)`, `description_placeholders(hass)`, `transform_user_input(...)`.
- `options/counters.py` — concrete `CountersSection`. Reads the local Vimar DB via `Database.instance().component_repo.get_all()` filtered by `SS_Energy_MeasureCounter`, builds a `SelectSelector` (Electricity / Water / Gas) per detected device, with `translation_key`
- `options/__init__.py` — `SECTIONS` registry (tuple of section classes).

`OptionsFlowHandler` in `config_flow.py`:

- Filters sections by `is_applicable`.
- Aborts with the generic `nothing_to_configure` reason when none are applicable.
- Short-circuits straight into the section's step when only one is applicable (no useless menu page for the typical user).
- Falls back to `async_show_menu` when more than one section applies.

## Backwards compatibility

The implementation is intended with no regression by default

- Fresh installs and upgrades alike land in the legacy `electricity` branch (`device_class=ENERGY`, `unit=kWh`, value `/1000`, `state_class=None`) until the user explicitly reconfigures a counter via the new Configure page. The integration's existing entities preserve their `entity_id`, `unique_id`, and historical schema.
- The `state_class=TOTAL_INCREASING` is added **only** to water/gas (new branches), so HA's long-term statistics for existing electricity counters are not affected.
- `entry.data` schema is unchanged. `entry.options` only gains an additive key (`counters`); no `async_migrate_entry` needed.

When a user does switch a counter from electricity to water/gas, HA will (correctly) flag a unit mismatch on long-term statistics for that entity. The expected user gesture is *Developer Tools → Statistics → Fix issue → accept the new unit*; this is unavoidable when the physical quantity changes.
