### PR TITLE
Feature/realtime update actions

### DIFF
--- a/custom_components/vimar_byme_plus/config_flow.py
+++ b/custom_components/vimar_byme_plus/config_flow.py
@@ -224,6 +224,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     ) -> ConfigFlowResult:
         return await self._render_section("counters", user_input)
 
+    async def async_step_realtime(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        return await self._render_section("realtime", user_input)
+
     # ------------------------------------------------------------------
 
     async def _render_section(

--- a/custom_components/vimar_byme_plus/const.py
+++ b/custom_components/vimar_byme_plus/const.py
@@ -26,6 +26,7 @@ DOCUMENTATION_URL = (
 
 # OptionsFlow section ids (each is a sub-key under entry.options)
 SECTION_COUNTERS: Final = "counters"
+SECTION_REALTIME: Final = "realtime"
 
 # Counter kinds (values stored under entry.options[SECTION_COUNTERS])
 COUNTER_ELECTRICITY: Final = "electricity"

--- a/custom_components/vimar_byme_plus/coordinator.py
+++ b/custom_components/vimar_byme_plus/coordinator.py
@@ -21,6 +21,7 @@ from .const import (
     PORT,
     PROTOCOL,
     SECTION_COUNTERS,
+    SECTION_REALTIME,
 )
 from .vimar.client.vimar_client import VimarClient
 from .vimar.model.component.vimar_component import VimarComponent
@@ -38,6 +39,10 @@ _LOGGER = logging.getLogger(__name__)
 # minutes (one watchdog tick after crossing the threshold).
 _WATCHDOG_INTERVAL = timedelta(minutes=5)
 _STALE_THRESHOLD_SECONDS = 300
+
+# Substring used by every "Aggiornamenti RealTime" button id, regardless
+# of whether it was produced by a sensor or energy mapper.
+_REALTIME_BUTTON_MARKER = "real_time"
 
 
 class Coordinator(DataUpdateCoordinator[VimarData]):
@@ -58,6 +63,7 @@ class Coordinator(DataUpdateCoordinator[VimarData]):
         self.client = VimarClient(self.gateway_info, self.update_data)
         self.client.set_setup_code(user_input.get(CODE))
         self._unsub_watchdog: Callable[[], None] | None = None
+        self._unsub_realtime: list[Callable[[], None]] = []
 
         super().__init__(hass, _LOGGER, name=DOMAIN)
 
@@ -69,6 +75,7 @@ class Coordinator(DataUpdateCoordinator[VimarData]):
         raw = self._entry.options or {}
         return IntegrationOptions(
             counter_types=raw.get(SECTION_COUNTERS, {}) or {},
+            realtime_intervals=raw.get(SECTION_REALTIME, {}) or {},
         )
 
     def associate(self):
@@ -80,9 +87,11 @@ class Coordinator(DataUpdateCoordinator[VimarData]):
         self.client.operational_phase()
         self.update_data()
         self._setup_watchdog()
+        self._setup_realtime()
 
     def stop(self):
         """Stop coordinator processes."""
+        self._teardown_realtime()
         self._teardown_watchdog()
         self.client.stop()
 
@@ -106,12 +115,6 @@ class Coordinator(DataUpdateCoordinator[VimarData]):
         return self.client.retrieve_data(self.options)
 
     # --- Watchdog -----------------------------------------------------
-    # The integration relies on a daemon thread (`VimarServiceThread`)
-    # for the gateway WebSocket loop. If that thread dies — or the
-    # broker stops sending messages without closing the TCP — there is
-    # no internal mechanism to detect it: HA keeps reading stale data
-    # from the local DB. The watchdog runs on the HA event loop and
-    # forces a reconnect in either case.
 
     def _setup_watchdog(self) -> None:
         if self._unsub_watchdog is not None:
@@ -136,6 +139,69 @@ class Coordinator(DataUpdateCoordinator[VimarData]):
             stale_seconds,
         )
         await self.hass.async_add_executor_job(self.client.reconnect)
+
+    # --- Realtime auto-press -----------------------------------------
+    # Per-device timers configured via OptionsFlow → SECTION_REALTIME.
+    # Each entry maps a Vimar device idsf (as string) to an interval in
+    # seconds; on every tick the corresponding "Aggiornamenti RealTime"
+    # button is pressed, which routes to the existing action handlers
+    # and emits SFE_Cmd_TimedDynamicMode = "Start" on the gateway.
+
+    def _setup_realtime(self) -> None:
+        self._teardown_realtime()
+        for main_id_str, raw_interval in self.options.realtime_intervals.items():
+            try:
+                seconds = int(raw_interval)
+            except (TypeError, ValueError):
+                continue
+            if seconds <= 0:
+                continue
+            unsub = async_track_time_interval(
+                self.hass,
+                self._make_realtime_callback(str(main_id_str)),
+                timedelta(seconds=seconds),
+            )
+            self._unsub_realtime.append(unsub)
+
+    def _teardown_realtime(self) -> None:
+        for unsub in self._unsub_realtime:
+            unsub()
+        self._unsub_realtime = []
+
+    def _make_realtime_callback(
+        self, main_id_str: str
+    ) -> Callable[[datetime], None]:
+        async def _cb(_now: datetime) -> None:
+            await self._fire_realtime_press(main_id_str)
+        return _cb
+
+    async def _fire_realtime_press(self, main_id_str: str) -> None:
+        if self.data is None:
+            return
+        target = next(
+            (
+                b
+                for b in self.data.get_buttons()
+                if _REALTIME_BUTTON_MARKER in b.id
+                and str(b.main_id) == main_id_str
+            ),
+            None,
+        )
+        if target is None:
+            _LOGGER.debug(
+                "Realtime tick: no button found for main_id=%s (skipping)",
+                main_id_str,
+            )
+            return
+        await self.hass.async_add_executor_job(self._send_realtime_press, target)
+
+    def _send_realtime_press(self, button: VimarComponent) -> None:
+        try:
+            self.client.send(button, ActionType.PRESS)
+        except Exception as exc:  # pylint: disable=broad-except
+            _LOGGER.warning(
+                "Realtime auto-press failed for %s: %r", button.id, exc
+            )
 
     def _get_gateway_info(self, user_input: dict[str, str]) -> GatewayInfo:
         return GatewayInfo(

--- a/custom_components/vimar_byme_plus/options/__init__.py
+++ b/custom_components/vimar_byme_plus/options/__init__.py
@@ -2,7 +2,11 @@
 
 from .base import OptionsSection
 from .counters import CountersSection
+from .realtime import RealtimeSection
 
-SECTIONS: tuple[type[OptionsSection], ...] = (CountersSection,)
+SECTIONS: tuple[type[OptionsSection], ...] = (
+    CountersSection,
+    RealtimeSection,
+)
 
 __all__ = ["OptionsSection", "SECTIONS"]

--- a/custom_components/vimar_byme_plus/options/counters.py
+++ b/custom_components/vimar_byme_plus/options/counters.py
@@ -1,6 +1,6 @@
-"""OptionsFlow section: per-device kind for SS_Energy_MeasureCounter (01452).
+"""OptionsFlow section: per-device kind for SS_Energy_MeasureCounter.
 
-Lets the user pick electricity / water / gas for each Vimar 01452 pulse
+Lets the user pick electricity / water / gas for each Vimar pulse
 counter so the integration applies the right device_class / unit /
 value scaling.
 """

--- a/custom_components/vimar_byme_plus/options/realtime.py
+++ b/custom_components/vimar_byme_plus/options/realtime.py
@@ -1,0 +1,130 @@
+"""OptionsFlow section: per-device auto-press of "Aggiornamenti RealTime".
+
+Lets the user pick, per real-time-update button currently exposed by
+the integration, the interval (in seconds) after which the Coordinator
+should automatically fire `SFE_Cmd_TimedDynamicMode = "Start"` on the
+gateway. 0 disables the auto-press for that device.
+
+The list of applicable buttons is read live from `coordinator.data` —
+this is the single source of truth for which devices currently produce
+a real-time button (sensors via `SsSensorGenericMapper` derivatives,
+energy meters via the issue #29 fix, etc.).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.selector import (
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+)
+
+from ..const import DOMAIN, SECTION_REALTIME
+from .base import OptionsSection
+
+_REALTIME_BUTTON_MARKER = "real_time"
+_MIN_INTERVAL = 0
+_MAX_INTERVAL = 3600
+_STEP = 1
+
+
+class RealtimeSection(OptionsSection):
+    """Auto-press interval picker per real-time button."""
+
+    id = SECTION_REALTIME
+
+    def __init__(self) -> None:
+        # Cached on build_schema, consumed in transform_user_input to
+        # convert from human-readable form keys back to the canonical
+        # idsf-keyed storage map.
+        self._buttons: list[Any] = []
+
+    async def is_applicable(self, hass: HomeAssistant) -> bool:
+        return bool(self._collect_buttons(hass))
+
+    async def build_schema(
+        self, hass: HomeAssistant, current: dict[str, Any]
+    ) -> vol.Schema:
+        buttons = self._collect_buttons(hass)
+        self._buttons = buttons
+        number = NumberSelector(
+            NumberSelectorConfig(
+                min=_MIN_INTERVAL,
+                max=_MAX_INTERVAL,
+                step=_STEP,
+                mode=NumberSelectorMode.BOX,
+                unit_of_measurement="s",
+            )
+        )
+        schema_dict: dict[Any, Any] = {}
+        for button in buttons:
+            label = self._label(button)
+            current_value = self._coerce_int(
+                current.get(str(button.main_id), 0)
+            )
+            schema_dict[
+                vol.Required(
+                    label,
+                    description={"suggested_value": current_value},
+                    default=0,
+                )
+            ] = number
+        return vol.Schema(schema_dict)
+
+    async def description_placeholders(
+        self, hass: HomeAssistant
+    ) -> dict[str, str]:
+        buttons = self._collect_buttons(hass)
+        return {
+            "count": str(len(buttons)),
+            "max_seconds": str(_MAX_INTERVAL),
+        }
+
+    async def transform_user_input(
+        self, hass: HomeAssistant, user_input: dict[str, Any]
+    ) -> dict[str, int]:
+        buttons = self._buttons or self._collect_buttons(hass)
+        label_to_main_id = {self._label(b): str(b.main_id) for b in buttons}
+        out: dict[str, int] = {}
+        for label, value in user_input.items():
+            main_id = label_to_main_id.get(label)
+            if main_id is None:
+                continue
+            out[main_id] = self._coerce_int(value)
+        return out
+
+    @staticmethod
+    def _label(button: Any) -> str:
+        # Disambiguate by appending the device idsf, in case two Vimar
+        # devices share the same friendly name.
+        return f"{button.name} (#{button.main_id})"
+
+    @staticmethod
+    def _coerce_int(value: Any) -> int:
+        try:
+            return max(_MIN_INTERVAL, min(_MAX_INTERVAL, int(float(value))))
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _collect_buttons(hass: HomeAssistant) -> list[Any]:
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            coordinator = getattr(entry, "runtime_data", None)
+            if coordinator is None:
+                continue
+            data = getattr(coordinator, "data", None)
+            if data is None:
+                continue
+            try:
+                buttons = data.get_buttons()
+            except Exception:  # pylint: disable=broad-except
+                continue
+            return [
+                b for b in buttons if _REALTIME_BUTTON_MARKER in b.id
+            ]
+        return []

--- a/custom_components/vimar_byme_plus/strings.json
+++ b/custom_components/vimar_byme_plus/strings.json
@@ -43,12 +43,17 @@
         "title": "Configure VIMAR By-me Plus HUB",
         "description": "Pick the section to configure.",
         "menu_options": {
-          "counters": "Pulse counter type (01452)"
+          "counters": "Pulse counter type",
+          "realtime": "Real-time auto-refresh interval"
         }
       },
       "counters": {
-        "title": "Pulse counter type (01452)",
-        "description": "For every Vimar 01452 pulse counter, pick the meter it is wired to (electricity / water / gas). Detected counters: {counters}"
+        "title": "Pulse counter type",
+        "description": "For every Vimar pulse counter, pick the meter it is wired to (electricity / water / gas). Detected counters: {counters}"
+      },
+      "realtime": {
+        "title": "Real-time auto-refresh interval",
+        "description": "For each device with a real-time update button, set the interval (in seconds) at which the integration should automatically request fast updates from the gateway. 0 disables the auto-refresh for that device. Range: 0–{max_seconds}s. Detected buttons: {count}."
       }
     }
   },

--- a/custom_components/vimar_byme_plus/translations/en.json
+++ b/custom_components/vimar_byme_plus/translations/en.json
@@ -43,12 +43,17 @@
                 "title": "Configure VIMAR By-me Plus HUB",
                 "description": "Pick the section to configure.",
                 "menu_options": {
-                    "counters": "Pulse counter type (01452)"
+                    "counters": "Pulse counter type",
+                    "realtime": "Real-time auto-refresh interval"
                 }
             },
             "counters": {
-                "title": "Pulse counter type (01452)",
-                "description": "For every Vimar 01452 pulse counter, pick the meter it is wired to (electricity / water / gas). Detected counters: {counters}"
+                "title": "Pulse counter type",
+                "description": "For every Vimar pulse counter, pick the meter it is wired to (electricity / water / gas). Detected counters: {counters}"
+            },
+            "realtime": {
+                "title": "Real-time auto-refresh interval",
+                "description": "For each device with a real-time update button, set the interval (in seconds) at which the integration should automatically request fast updates from the gateway. 0 disables the auto-refresh for that device. Range: 0–{max_seconds}s. Detected buttons: {count}."
             }
         }
     },

--- a/custom_components/vimar_byme_plus/translations/it.json
+++ b/custom_components/vimar_byme_plus/translations/it.json
@@ -43,12 +43,17 @@
                 "title": "Configura VIMAR By-me Plus HUB",
                 "description": "Scegli la sezione da configurare.",
                 "menu_options": {
-                    "counters": "Tipo pulse counter (01452)"
+                    "counters": "Tipo pulse counter",
+                    "realtime": "Intervallo aggiornamenti realtime"
                 }
             },
             "counters": {
-                "title": "Tipo pulse counter (01452)",
-                "description": "Per ogni pulse counter Vimar 01452, seleziona il tipo di contatore a cui è cablato (elettricità / acqua / gas). Counter rilevati: {counters}"
+                "title": "Tipo pulse counter",
+                "description": "Per ogni pulse counter Vimar, seleziona il tipo di contatore a cui è cablato (elettricità / acqua / gas). Counter rilevati: {counters}"
+            },
+            "realtime": {
+                "title": "Intervallo aggiornamenti realtime",
+                "description": "Per ogni dispositivo con pulsante \"Aggiornamenti RealTime\", imposta l'intervallo (in secondi) dopo il quale l'integrazione richiede automaticamente aggiornamenti rapidi al gateway. 0 disabilita la richiesta automatica per quel dispositivo. Range: 0–{max_seconds}s. Pulsanti rilevati: {count}."
             }
         }
     },

--- a/custom_components/vimar_byme_plus/vimar/model/integration_options.py
+++ b/custom_components/vimar_byme_plus/vimar/model/integration_options.py
@@ -15,3 +15,7 @@ class IntegrationOptions:
     """Materialised values for every OptionsFlow section."""
 
     counter_types: dict[str, str] = field(default_factory=dict)
+    # Per-device auto-refresh interval (seconds) for the
+    # SFE_Cmd_TimedDynamicMode trigger. Keyed by device idsf as str.
+    # 0 (or absent) = disabled — preserves zero-regression on upgrade.
+    realtime_intervals: dict[str, int] = field(default_factory=dict)


### PR DESCRIPTION
## Summary

Adds a new `realtime` section to the OptionsFlow, letting users configure — per device — the interval at which the integration automatically presses the "Aggiornamenti RealTime" button (sending `SFE_Cmd_TimedDynamicMode = "Start"` to the gateway). 0 disables the auto-trigger for that device.

The integration now does the periodic dynamic-mode re-trigger natively, configurable from the UI, with one timer per
device and per-device intervals.


## Why

`SFE_Cmd_TimedDynamicMode` is the command the Vimar View app sends to keep power meters fresh — it tells the broker to push measurement data in a high-frequency, time-bounded mode. The integration already exposes an "RealTime Updates" button on every device that supports the command (sensors via `SsSensorGenericMapper`, energy meters via the issue #29 fix), but the dynamic mode is *temporary*: without a periodic re-trigger, readings go back to slow updates after a few minutes.