### PR TITLE
feat: ss_scene_activator_sai added

### DIFF
--- a/custom_components/vimar_byme_plus/vimar/database/repository/base_repo.py
+++ b/custom_components/vimar_byme_plus/vimar/database/repository/base_repo.py
@@ -15,7 +15,7 @@ class BaseRepo:
     def execute(self, query, params: tuple = ()):
         cursor = self.cursor()
         try:
-            log_debug(__name__, f"Executing query: {query} with params: {params}")
+            # log_debug(__name__, f"Executing query: {query} with params: {params}")
             if params and isinstance(params, (tuple)):
                 cursor.execute(query, params)
             elif params and isinstance(params, list):
@@ -23,6 +23,6 @@ class BaseRepo:
             else:
                 cursor.execute(query)
             self._connection.commit()
-            log_debug(__name__, "Query executed successfully")
+            # log_debug(__name__, "Query executed successfully")
         except Error as e:
             log_error(__name__, f"The error '{e}' occurred")

--- a/custom_components/vimar_byme_plus/vimar/mapper/scene_activator/ss_scene_activator_sai_g2_mapper.py
+++ b/custom_components/vimar_byme_plus/vimar/mapper/scene_activator/ss_scene_activator_sai_g2_mapper.py
@@ -2,12 +2,39 @@ from ...model.component.vimar_button import VimarButton
 from ...model.enum.sstype_enum import SsType
 from ...model.repository.user_component import UserComponent
 
+_BUTTONS: list[tuple[str, str]] = [
+    ("dis", "Disinserimento"),
+    ("alarm", "Allarme"),
+    ("alarm_memory", "Memoria allarme"),
+    ("alarm_memory_reset", "Reset memoria allarme"),
+    ("alarm_reset", "Reset allarme"),
+    ("par_a", "Parziale A"),
+    ("par_b", "Parziale B"),
+    ("par_c", "Parziale C"),
+    ("par_d", "Parziale D"),
+    ("total", "Totale"),
+]
+
 
 class SsSceneActivatorSaiG2Mapper:
     SSTYPE = SsType.SCENE_ACTIVATOR_SAI_G2.value
 
     def from_obj(self, component: UserComponent, *args) -> list[VimarButton]:
-        return [self._from_obj(component, *args)]
+        return [
+            self._button_from_obj(component, suffix, label)
+            for suffix, label in _BUTTONS
+        ]
 
-    def _from_obj(self, component: UserComponent, *args) -> VimarButton:
-        raise NotImplementedError
+    def _button_from_obj(
+        self, component: UserComponent, suffix: str, label: str
+    ) -> VimarButton:
+        return VimarButton(
+            id=str(component.idsf) + "_" + suffix,
+            name=component.name + " - " + label,
+            device_group=component.sftype,
+            device_name=component.sstype,
+            device_class=None,
+            area=component.ambient.name,
+            main_id=component.idsf,
+            executed=False,
+        )

--- a/custom_components/vimar_byme_plus/vimar/mapper/scene_activator/ss_scene_activator_sai_mapper.py
+++ b/custom_components/vimar_byme_plus/vimar/mapper/scene_activator/ss_scene_activator_sai_mapper.py
@@ -2,12 +2,37 @@ from ...model.component.vimar_button import VimarButton
 from ...model.enum.sstype_enum import SsType
 from ...model.repository.user_component import UserComponent
 
+_BUTTONS: list[tuple[str, str]] = [
+    ("dis", "Disinserimento"),
+    ("on", "Inserimento totale"),
+    ("int", "Inserimento intermedio"),
+    ("par", "Inserimento parziale"),
+    ("alarm", "Allarme"),
+    ("alarm_memory", "Memoria allarme"),
+    ("alarm_memory_reset", "Reset memoria allarme"),
+    ("alarm_reset", "Reset allarme"),
+]
+
 
 class SsSceneActivatorSaiMapper:
     SSTYPE = SsType.SCENE_ACTIVATOR_SAI.value
 
     def from_obj(self, component: UserComponent, *args) -> list[VimarButton]:
-        return [self._from_obj(component, *args)]
+        return [
+            self._button_from_obj(component, suffix, label)
+            for suffix, label in _BUTTONS
+        ]
 
-    def _from_obj(self, component: UserComponent, *args) -> VimarButton:
-        raise NotImplementedError
+    def _button_from_obj(
+        self, component: UserComponent, suffix: str, label: str
+    ) -> VimarButton:
+        return VimarButton(
+            id=str(component.idsf) + "_" + suffix,
+            name=component.name + " - " + label,
+            device_group=component.sftype,
+            device_name=component.sstype,
+            device_class=None,
+            area=component.ambient.name,
+            main_id=component.idsf,
+            executed=False,
+        )

--- a/custom_components/vimar_byme_plus/vimar/model/enum/sfetype_enum.py
+++ b/custom_components/vimar_byme_plus/vimar/model/enum/sfetype_enum.py
@@ -44,6 +44,11 @@ class SfeType(Enum):
     CMD_AREA_ALARM_MEMORY_ACTIVE_SCENE = "SFE_Cmd_AreaAlarmMemory_ActiveScene"
     CMD_AREA_ALARM_MEMORY_RESET_ACTIVE_SCENE = "SFE_Cmd_AreaAlarmMemoryReset_ActiveScene"
     CMD_AREA_ALARM_RESET_ACTIVE_SCENE = "SFE_Cmd_AreaAlarmReset_ActiveScene"
+    CMD_AREA_PAR_A_ACTIVE_SCENE = "SFE_Cmd_AreaParA_ActiveScene"
+    CMD_AREA_PAR_B_ACTIVE_SCENE = "SFE_Cmd_AreaParB_ActiveScene"
+    CMD_AREA_PAR_C_ACTIVE_SCENE = "SFE_Cmd_AreaParC_ActiveScene"
+    CMD_AREA_PAR_D_ACTIVE_SCENE = "SFE_Cmd_AreaParD_ActiveScene"
+    CMD_AREA_TOTAL_ACTIVE_SCENE = "SFE_Cmd_AreaTotal_ActiveScene"
 
     CMD_AIR_QUALITY_GRADIENT_DESCENDING_ACTIVE_SCENE = (
         "SFE_Cmd_AirQualityGradientDescending_ActiveScene"

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/scene_activator/scene_activator_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/scene_activator/scene_activator_action_handler.py
@@ -8,6 +8,10 @@ from .ss_scene_activator_activator_action_handler import (
 from .ss_scene_activator_air_quality_gradient_action_handler import (
     SsSceneActivatorAirQualityGradientActionHandler,
 )
+from .ss_scene_activator_sai_action_handler import SsSceneActivatorSaiActionHandler
+from .ss_scene_activator_sai_g2_action_handler import (
+    SsSceneActivatorSaiG2ActionHandler,
+)
 from .ss_scene_activator_video_entry_action_handler import (
     SsSceneActivatorVideoEntryActionHandler,
 )
@@ -27,6 +31,10 @@ class SceneActivatorActionHandler:
             return SsSceneActivatorActivatorActionHandler()
         if sstype == SsSceneActivatorAirQualityGradientActionHandler.SSTYPE:
             return SsSceneActivatorAirQualityGradientActionHandler()
+        if sstype == SsSceneActivatorSaiActionHandler.SSTYPE:
+            return SsSceneActivatorSaiActionHandler()
+        if sstype == SsSceneActivatorSaiG2ActionHandler.SSTYPE:
+            return SsSceneActivatorSaiG2ActionHandler()
         if sstype == SsSceneActivatorVideoEntryActionHandler.SSTYPE:
             return SsSceneActivatorVideoEntryActionHandler()
         raise NotImplementedError

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/scene_activator/ss_scene_activator_sai_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/scene_activator/ss_scene_activator_sai_action_handler.py
@@ -1,0 +1,41 @@
+from .....model.component.vimar_action import VimarAction
+from .....model.component.vimar_button import VimarButton
+from .....model.enum.sfetype_enum import SfeType
+from .....model.enum.sstype_enum import SsType
+from .ss_scene_activator_activator_action_handler import (
+    SsSceneActivatorActivatorActionHandler,
+)
+
+# Mapping suffisso button-id → Cmd Vimar. Le chiavi devono coincidere con
+# i suffissi usati in SsSceneActivatorSaiMapper.
+_SUFFIX_TO_CMD: dict[str, SfeType] = {
+    "dis": SfeType.CMD_AREA_DIS_ACTIVE_SCENE,
+    "on": SfeType.CMD_AREA_ON_ACTIVE_SCENE,
+    "int": SfeType.CMD_AREA_INT_ACTIVE_SCENE,
+    "par": SfeType.CMD_AREA_PAR_ACTIVE_SCENE,
+    "alarm": SfeType.CMD_AREA_ALARM_ACTIVE_SCENE,
+    "alarm_memory": SfeType.CMD_AREA_ALARM_MEMORY_ACTIVE_SCENE,
+    "alarm_memory_reset": SfeType.CMD_AREA_ALARM_MEMORY_RESET_ACTIVE_SCENE,
+    "alarm_reset": SfeType.CMD_AREA_ALARM_RESET_ACTIVE_SCENE,
+}
+
+
+class SsSceneActivatorSaiActionHandler(SsSceneActivatorActivatorActionHandler):
+    SSTYPE = SsType.SCENE_ACTIVATOR_SAI.value
+    _SUFFIX_TO_CMD = _SUFFIX_TO_CMD
+
+    def get_press_actions(self, component: VimarButton) -> list[VimarAction]:
+        suffix = self._extract_suffix(component.id)
+        cmd = self._SUFFIX_TO_CMD.get(suffix)
+        if cmd is None:
+            raise NotImplementedError
+        return [self._action(component.id, cmd, "Execute")]
+
+    @staticmethod
+    def _extract_suffix(button_id: str) -> str:
+        # button_id has the shape "<idsf>_<suffix>" — split on the first
+        # underscore so multi-word suffixes (e.g. "alarm_memory_reset")
+        # survive intact.
+        if "_" not in str(button_id):
+            return ""
+        return str(button_id).split("_", 1)[1]

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/scene_activator/ss_scene_activator_sai_g2_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/scene_activator/ss_scene_activator_sai_g2_action_handler.py
@@ -1,0 +1,24 @@
+from .....model.enum.sfetype_enum import SfeType
+from .....model.enum.sstype_enum import SsType
+from .ss_scene_activator_sai_action_handler import SsSceneActivatorSaiActionHandler
+
+# Mapping suffisso button-id → Cmd Vimar per Saig2. Condivide 5 chiavi
+# con Sai (dis/alarm/alarm_memory/alarm_memory_reset/alarm_reset) e ne
+# aggiunge 5 specifiche (par_a/b/c/d, total).
+_SUFFIX_TO_CMD: dict[str, SfeType] = {
+    "dis": SfeType.CMD_AREA_DIS_ACTIVE_SCENE,
+    "alarm": SfeType.CMD_AREA_ALARM_ACTIVE_SCENE,
+    "alarm_memory": SfeType.CMD_AREA_ALARM_MEMORY_ACTIVE_SCENE,
+    "alarm_memory_reset": SfeType.CMD_AREA_ALARM_MEMORY_RESET_ACTIVE_SCENE,
+    "alarm_reset": SfeType.CMD_AREA_ALARM_RESET_ACTIVE_SCENE,
+    "par_a": SfeType.CMD_AREA_PAR_A_ACTIVE_SCENE,
+    "par_b": SfeType.CMD_AREA_PAR_B_ACTIVE_SCENE,
+    "par_c": SfeType.CMD_AREA_PAR_C_ACTIVE_SCENE,
+    "par_d": SfeType.CMD_AREA_PAR_D_ACTIVE_SCENE,
+    "total": SfeType.CMD_AREA_TOTAL_ACTIVE_SCENE,
+}
+
+
+class SsSceneActivatorSaiG2ActionHandler(SsSceneActivatorSaiActionHandler):
+    SSTYPE = SsType.SCENE_ACTIVATOR_SAI_G2.value
+    _SUFFIX_TO_CMD = _SUFFIX_TO_CMD


### PR DESCRIPTION
## Summary

Implements two previously stubbed Vimar scene activator types so that intrusion-alarm panels (SAI) appear in Home Assistant as actionable button entities:

- `SS_SceneActivator_Sai` — first-generation SAI panels, 8 commands.
- `SS_SceneActivator_Saig2` — second-generation SAI panels, 10 commands.

Both types previously raised `NotImplementedError` from their mappers, which was caught at the dispatcher level and logged as `Component of type SS_SceneActivator_Sai not yet implemented!`. After this PR they produce one HA `button` per command, wired to the matching Vimar `SFE_Cmd_Area*_ActiveScene` write.

## Limitations

- These two types are **write-only** in the Vimar protocol: there is no `SFE_State_*` field telling HA the panel's current arm state. The buttons therefore drive the panel but cannot reflect its current status. Wiring up a proper HA `alarm_control_panel` entity seems not be possible at the moment