### PR TITLE
multi-gateway implementation

### DIFF
--- a/custom_components/vimar_byme_plus/__init__.py
+++ b/custom_components/vimar_byme_plus/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from functools import partial
+
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
@@ -35,7 +37,10 @@ RESTART_SERVICE_SCHEMA = vol.Schema(
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: CoordinatorConfigEntry) -> bool:
-    """Set up Hello World from a config entry."""
+    """Set up the integration from a config entry."""
+    gateway_id = entry.data.get(GATEWAY_ID)
+    if gateway_id:
+        await hass.async_add_executor_job(Database.instance, gateway_id)
     coordinator = Coordinator(hass, entry.data, entry)
     await coordinator.async_config_entry_first_refresh()
     await start(coordinator)
@@ -67,9 +72,10 @@ async def _async_options_updated(
 async def async_remove_entry(
     hass: HomeAssistant, entry: CoordinatorConfigEntry
 ) -> None:
-    """Cleanup when an entry is fully removed by the user."""
     gateway_id = entry.data.get(GATEWAY_ID)
-    Database.remove(gateway_id, delete_file=True)
+    if not gateway_id:
+        return
+    await hass.async_add_executor_job(partial(Database.remove, gateway_id, delete_file=True))
 
 
 async def start(coordinator: Coordinator):

--- a/custom_components/vimar_byme_plus/__init__.py
+++ b/custom_components/vimar_byme_plus/__init__.py
@@ -9,8 +9,9 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 
-from .const import DOMAIN
+from .const import DOMAIN, GATEWAY_ID
 from .coordinator import Coordinator
+from .vimar.database.database import Database
 from .vimar.model.exceptions import CodeNotValidException, VimarErrorResponseException
 
 PLATFORMS = [
@@ -61,6 +62,14 @@ async def _async_options_updated(
 ) -> None:
     """Reload integration when options change."""
     await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_remove_entry(
+    hass: HomeAssistant, entry: CoordinatorConfigEntry
+) -> None:
+    """Cleanup when an entry is fully removed by the user."""
+    gateway_id = entry.data.get(GATEWAY_ID)
+    Database.remove(gateway_id, delete_file=True)
 
 
 async def start(coordinator: Coordinator):

--- a/custom_components/vimar_byme_plus/config_flow.py
+++ b/custom_components/vimar_byme_plus/config_flow.py
@@ -198,7 +198,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry: ConfigEntry) -> None:
         self._entry = config_entry
         self._sections: dict[str, OptionsSection] = {
-            cls.id: cls() for cls in SECTIONS
+            cls.id: cls(config_entry) for cls in SECTIONS
         }
 
     async def async_step_init(

--- a/custom_components/vimar_byme_plus/options/base.py
+++ b/custom_components/vimar_byme_plus/options/base.py
@@ -12,6 +12,10 @@ Adding a new section requires:
      delegating to `_handle_section_step`,
   4. translation entries under `options.step.<section_id>` and a label
      under `options.step.init.menu_options.<section_id>`.
+
+Sections receive the `ConfigEntry` they're configuring at construction
+time (so they can scope their lookups to a specific gateway in
+multi-gateway installs).
 """
 
 from __future__ import annotations
@@ -21,6 +25,7 @@ from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 
@@ -28,6 +33,9 @@ class OptionsSection(ABC):
     """A configurable section in the OptionsFlow."""
 
     id: str  # unique id, also key under entry.options
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        self._entry = entry
 
     @abstractmethod
     async def is_applicable(self, hass: HomeAssistant) -> bool:

--- a/custom_components/vimar_byme_plus/options/counters.py
+++ b/custom_components/vimar_byme_plus/options/counters.py
@@ -1,9 +1,4 @@
-"""OptionsFlow section: per-device kind for SS_Energy_MeasureCounter.
-
-Lets the user pick electricity / water / gas for each Vimar pulse
-counter so the integration applies the right device_class / unit /
-value scaling.
-"""
+"""OptionsFlow section: per-device kind for SS_Energy_MeasureCounter."""
 
 from __future__ import annotations
 
@@ -11,6 +6,7 @@ from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import (
     SelectSelector,
@@ -22,6 +18,7 @@ from ..const import (
     COUNTER_ELECTRICITY,
     COUNTER_GAS,
     COUNTER_WATER,
+    GATEWAY_ID,
     SECTION_COUNTERS,
 )
 from ..vimar.database.database import Database
@@ -34,7 +31,8 @@ class CountersSection(OptionsSection):
 
     id = SECTION_COUNTERS
 
-    def __init__(self) -> None:
+    def __init__(self, entry: ConfigEntry) -> None:
+        super().__init__(entry)
         # Cached on build_schema, consumed in transform_user_input to
         # convert from human-readable form labels back to idsf-keyed
         # storage.
@@ -94,15 +92,13 @@ class CountersSection(OptionsSection):
 
     @staticmethod
     def _label(idsf: int, name: str) -> str:
-        # Disambiguate by appending the device idsf, in case two Vimar
-        # devices share the same friendly name.
         return f"{name} (#{idsf})"
 
-    @staticmethod
-    def _get_counters() -> list[tuple[int, str]]:
+    def _get_counters(self) -> list[tuple[int, str]]:
         try:
-            components = Database.instance().component_repo.get_all()
+            gateway_id = self._entry.data.get(GATEWAY_ID)
+            components = Database.instance(gateway_id).component_repo.get_all()
+            sstype = SsType.ENERGY_MEASURE_COUNTER.value
+            return [(c.idsf, c.name) for c in components if c.sstype == sstype]
         except Exception:  # pylint: disable=broad-except
             return []
-        sstype = SsType.ENERGY_MEASURE_COUNTER.value
-        return [(c.idsf, c.name) for c in components if c.sstype == sstype]

--- a/custom_components/vimar_byme_plus/options/realtime.py
+++ b/custom_components/vimar_byme_plus/options/realtime.py
@@ -1,15 +1,4 @@
-"""OptionsFlow section: per-device auto-press of "Aggiornamenti RealTime".
-
-Lets the user pick, per real-time-update button currently exposed by
-the integration, the interval (in seconds) after which the Coordinator
-should automatically fire `SFE_Cmd_TimedDynamicMode = "Start"` on the
-gateway. 0 disables the auto-press for that device.
-
-The list of applicable buttons is read live from `coordinator.data` —
-this is the single source of truth for which devices currently produce
-a real-time button (sensors via `SsSensorGenericMapper` derivatives,
-energy meters via the issue #29 fix, etc.).
-"""
+"""OptionsFlow section: per-device auto-press of "Aggiornamenti RealTime"."""
 
 from __future__ import annotations
 
@@ -17,6 +6,7 @@ from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import (
     NumberSelector,
@@ -24,8 +14,10 @@ from homeassistant.helpers.selector import (
     NumberSelectorMode,
 )
 
-from ..const import DOMAIN, SECTION_REALTIME
+from ..const import SECTION_REALTIME
 from .base import OptionsSection
+from ..vimar.model.gateway.vimar_data import VimarData
+from ..vimar.model.component.vimar_button import VimarButton
 
 _REALTIME_BUTTON_MARKER = "real_time"
 _MIN_INTERVAL = 0
@@ -38,19 +30,20 @@ class RealtimeSection(OptionsSection):
 
     id = SECTION_REALTIME
 
-    def __init__(self) -> None:
+    def __init__(self, entry: ConfigEntry) -> None:
+        super().__init__(entry)
         # Cached on build_schema, consumed in transform_user_input to
         # convert from human-readable form keys back to the canonical
         # idsf-keyed storage map.
-        self._buttons: list[Any] = []
+        self._buttons: list[VimarButton] = []
 
     async def is_applicable(self, hass: HomeAssistant) -> bool:
-        return bool(self._collect_buttons(hass))
+        return bool(self._collect_buttons())
 
     async def build_schema(
         self, hass: HomeAssistant, current: dict[str, Any]
     ) -> vol.Schema:
-        buttons = self._collect_buttons(hass)
+        buttons = self._collect_buttons()
         self._buttons = buttons
         number = NumberSelector(
             NumberSelectorConfig(
@@ -79,7 +72,7 @@ class RealtimeSection(OptionsSection):
     async def description_placeholders(
         self, hass: HomeAssistant
     ) -> dict[str, str]:
-        buttons = self._collect_buttons(hass)
+        buttons = self._collect_buttons()
         return {
             "count": str(len(buttons)),
             "max_seconds": str(_MAX_INTERVAL),
@@ -88,7 +81,7 @@ class RealtimeSection(OptionsSection):
     async def transform_user_input(
         self, hass: HomeAssistant, user_input: dict[str, Any]
     ) -> dict[str, int]:
-        buttons = self._buttons or self._collect_buttons(hass)
+        buttons = self._buttons or self._collect_buttons()
         label_to_main_id = {self._label(b): str(b.main_id) for b in buttons}
         out: dict[str, int] = {}
         for label, value in user_input.items():
@@ -99,9 +92,7 @@ class RealtimeSection(OptionsSection):
         return out
 
     @staticmethod
-    def _label(button: Any) -> str:
-        # Disambiguate by appending the device idsf, in case two Vimar
-        # devices share the same friendly name.
+    def _label(button: VimarButton) -> str:
         return f"{button.name} (#{button.main_id})"
 
     @staticmethod
@@ -111,20 +102,11 @@ class RealtimeSection(OptionsSection):
         except (TypeError, ValueError):
             return 0
 
-    @staticmethod
-    def _collect_buttons(hass: HomeAssistant) -> list[Any]:
-        for entry in hass.config_entries.async_entries(DOMAIN):
-            coordinator = getattr(entry, "runtime_data", None)
-            if coordinator is None:
-                continue
-            data = getattr(coordinator, "data", None)
-            if data is None:
-                continue
-            try:
-                buttons = data.get_buttons()
-            except Exception:  # pylint: disable=broad-except
-                continue
-            return [
-                b for b in buttons if _REALTIME_BUTTON_MARKER in str(b.id)
-            ]
-        return []
+    def _collect_buttons(self) -> list[VimarButton]:
+        try:
+            coordinator = self._entry.runtime_data
+            data: VimarData = coordinator.data
+            buttons: list[VimarButton] = data.get_buttons()
+            return [b for b in buttons if _REALTIME_BUTTON_MARKER in str(b.id)]
+        except Exception:  # pylint: disable=broad-except
+            return []

--- a/custom_components/vimar_byme_plus/vimar/client/vimar_client.py
+++ b/custom_components/vimar_byme_plus/vimar/client/vimar_client.py
@@ -12,6 +12,9 @@ from ..model.integration_options import IntegrationOptions
 from ..model.repository.user_credentials import UserCredentials
 from ..service.association_service import AssociationService
 from ..service.operational_service import OperationalService, Update
+from ..database.repository.component_repo import ComponentRepo
+from ..database.repository.user_repo import UserRepo
+
 from ..utils.logger import log_info
 from ..utils.thread import Thread
 from ..utils.thread_monitor import thread_exists
@@ -22,12 +25,15 @@ class VimarClient:
 
     _association_service: AssociationService
     _operational_service: OperationalService
-    _component_repo = Database.instance().component_repo
-    _user_repo = Database.instance().user_repo
+    _component_repo: ComponentRepo
+    _user_repo: UserRepo
     _thread_name = "VimarServiceThread"
 
     def __init__(self, gateway_info: GatewayInfo, callback: Update) -> None:
         """Initialize the coordinator."""
+        db = Database.instance(gateway_info.deviceuid)
+        self._component_repo = db.component_repo
+        self._user_repo = db.user_repo
         self._association_service = AssociationService(gateway_info)
         self._operational_service = OperationalService(gateway_info, callback)
 

--- a/custom_components/vimar_byme_plus/vimar/database/database.py
+++ b/custom_components/vimar_byme_plus/vimar/database/database.py
@@ -1,16 +1,32 @@
-import sqlite3
-from sqlite3 import Connection, Error
-from typing import Optional
+"""Per-gateway SQLite registry.
 
-from ..utils.file import get_file_path
+The integration historically used a single global `home.db` and a
+classic singleton `Database`. With multi-gateway support every gateway
+gets its own file `home_<sanitized_deviceuid>.db` and `Database.instance`
+becomes a registry keyed by `gateway_id`.
+
+Migration: on first lookup for a gateway, if the legacy `home.db`
+exists and no other `home_*.db` files are present, it is renamed to
+`home_<gateway_id>.db` so existing single-gateway installs preserve
+their data transparently.
+"""
+
+import os
+import re
+import sqlite3
+import threading
+from sqlite3 import Connection, Error
+
+from ..utils.file import get_data_path, get_file_path
 from ..utils.logger import log_error, log_info
 from .repository.ambient_repo import AmbientRepo
 from .repository.component_repo import ComponentRepo
 from .repository.element_repo import ElementRepo
 from .repository.user_repo import UserRepo
 
-DATABASE_NAME = "home.db"
-
+_LEGACY_DATABASE_NAME = "home.db"
+_DATABASE_PREFIX = "home_"
+_DATABASE_SUFFIX = ".db"
 
 class Database:
     ambient_repo: AmbientRepo
@@ -18,31 +34,121 @@ class Database:
     element_repo: ElementRepo
     user_repo: UserRepo
 
-    _instance: Optional["Database"] = None
-    _connection: Connection = None
+    _instances: dict[str, "Database"] = {}
+    _instances_lock = threading.Lock()
+    _connection: Connection | None = None
 
-    def __new__(cls):
-        raise NotImplementedError("Use Database.instance() instead")
+    def __new__(cls, *args, **kwargs):
+        raise NotImplementedError("Use Database.instance(gateway_id) instead")
+
 
     @classmethod
-    def instance(cls):
-        if cls._instance is None:
-            cls._instance = super(Database, cls).__new__(cls)
-            cls._instance._initialize()
-        return cls._instance
+    def instance(cls, gateway_id: str) -> "Database":
+        key = cls._sanitize(gateway_id)
+        with cls._instances_lock:
+            if key not in cls._instances:
+                inst = object.__new__(cls)
+                inst._initialize(key)
+                cls._instances[key] = inst
+            return cls._instances[key]
 
-    def _initialize(self):
-        conn = self.create_connection()
+
+    @classmethod
+    def remove(cls, gateway_id: str, *, delete_file: bool = False) -> None:
+        key = cls._sanitize(gateway_id)
+        with cls._instances_lock:
+            inst = cls._instances.pop(key, None)
+        if inst and inst._connection is not None:
+            try:
+                inst._connection.close()
+            except Error as err:
+                log_error(__name__, f"Error closing connection for {key}: {err}")
+        if delete_file:
+            cls._delete_file(key)
+
+
+    @staticmethod
+    def _delete_file(key: str) -> None:
+        path = get_file_path(_DATABASE_PREFIX + key + _DATABASE_SUFFIX)
+        try:
+            if os.path.exists(path):
+                os.remove(path)
+                log_info(__name__, f"Removed database file {path}")
+        except OSError as err:
+            log_error(__name__, f"Could not remove {path}: {err}")
+
+
+    @staticmethod
+    def _sanitize(gateway_id: str) -> str:
+        # Keep filenames safe by replacing unexpected characters in deviceuid
+        return re.sub(r"[^A-Za-z0-9_-]", "_", str(gateway_id))
+
+
+    def _initialize(self, key: str) -> None:
+        target = get_file_path(_DATABASE_PREFIX + key + _DATABASE_SUFFIX)
+        self._migrate_legacy_if_needed(target)
+        self._heal_empty_files(target)
+        conn = self._create_connection(target)
         self.element_repo = ElementRepo(conn)
         self.ambient_repo = AmbientRepo(conn)
         self.user_repo = UserRepo(conn)
         self.component_repo = ComponentRepo(conn, self.element_repo)
+        conn.commit()
 
-    def create_connection(self) -> Connection:
+
+    @staticmethod
+    def _migrate_legacy_if_needed(target: str) -> None:
+        """Rename `home.db` > `home_<key>.db` for legacy single-gateway installs."""
+        if os.path.exists(target):
+            return
+        legacy = get_file_path(_LEGACY_DATABASE_NAME)
+        if not os.path.exists(legacy):
+            return
+        if Database._get_siblings():
+            log_info(__name__, f"Legacy {_LEGACY_DATABASE_NAME} found but other gateway database files exist; leaving it untouched (manual cleanup may be needed).")
+            return
+        Database._migrate(legacy, target)
+    
+    
+    @staticmethod
+    def _migrate(legacy: str, target: str) -> None:
         try:
-            file_path = get_file_path(DATABASE_NAME)
+            os.rename(legacy, target)
+            log_info(__name__, f"Migrated legacy {_LEGACY_DATABASE_NAME} -> {os.path.basename(target)}")
+        except OSError as err:
+            log_error(__name__, f"Failed to migrate legacy db: {err}")
+
+
+    @staticmethod
+    def _get_siblings() -> list[str]:
+        try:
+            data_dir = get_data_path()
+            return [
+                f
+                for f in os.listdir(data_dir)
+                if f.startswith(_DATABASE_PREFIX) and f.endswith(_DATABASE_SUFFIX)
+            ]
+        except OSError:
+            return []
+
+
+    @staticmethod
+    def _heal_empty_files(target: str) -> None:
+        """Delete 0-byte database files so SQLite can re-create the schema. Such files are produced by previous failed inits where DDL was never committed before the connection was closed."""
+        for path in (target, get_file_path(_LEGACY_DATABASE_NAME)):
+            try:
+                if os.path.exists(path) and os.path.getsize(path) == 0:
+                    os.remove(path)
+                    log_info(__name__, f"Removed empty {os.path.basename(path)} left by a previous failed init",)
+            except OSError as err:
+                log_error(__name__, f"Could not heal empty db {path}: {err}")
+
+
+    def _create_connection(self, file_path: str) -> Connection:
+        try:
             self._connection = sqlite3.connect(file_path, check_same_thread=False)
-            log_info(__name__, "Connection to SQLite DB successful")
+            log_info(__name__, f"Connection to SQLite DB successful ({file_path})")
             return self._connection
-        except Error as e:
-            log_error(__name__, f"Error occurred: {e}")
+        except Error as err:
+            log_error(__name__, f"Error opening {file_path}: {err}")
+            raise

--- a/custom_components/vimar_byme_plus/vimar/database/database.py
+++ b/custom_components/vimar_byme_plus/vimar/database/database.py
@@ -54,7 +54,9 @@ class Database:
 
 
     @classmethod
-    def remove(cls, gateway_id: str, *, delete_file: bool = False) -> None:
+    def remove(cls, gateway_id: str | None, *, delete_file: bool = False) -> None:
+        if not gateway_id:
+            return
         key = cls._sanitize(gateway_id)
         with cls._instances_lock:
             inst = cls._instances.pop(key, None)

--- a/custom_components/vimar_byme_plus/vimar/service/association_service.py
+++ b/custom_components/vimar_byme_plus/vimar/service/association_service.py
@@ -2,6 +2,7 @@ from ..client.authenticator_client import AuthenticatorClient
 from ..client.web_service.sync_attach_phase import SyncAttachPhase
 from ..client.web_service.sync_session_phase import SyncSessionPhase
 from ..database.database import Database
+from ..database.repository.user_repo import UserRepo
 from ..model.exceptions import VimarErrorResponseException
 from ..model.gateway.gateway_info import GatewayInfo
 from ..model.repository.user_credentials import UserCredentials
@@ -19,7 +20,7 @@ class AssociationService:
     attach_port: int | None = None
 
     _message_handler: MessageHandler
-    _user_repo = Database.instance().user_repo
+    _user_repo: UserRepo
     _authenticator_client = AuthenticatorClient()
 
     def __init__(self, gateway_info: GatewayInfo) -> None:
@@ -27,6 +28,7 @@ class AssociationService:
         self.gateway_address = gateway_info.address
         self.session_port = gateway_info.port
         self.gateway_info = gateway_info
+        self._user_repo = Database.instance(gateway_info.deviceuid).user_repo
         self._message_handler = MessageHandler(gateway_info)
 
     def associate(self):

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/action_handler.py
@@ -17,37 +17,41 @@ from .shutter.shutter_action_handler import ShutterActionHandler
 
 
 class ActionHandler:
+
+    def __init__(self, gateway_id: str) -> None:
+        self._gateway_id = gateway_id
+
     def get_actions(
         self, component: VimarComponent, action_type: ActionType, *args
     ) -> list[VimarAction]:
-        handler = ActionHandler._get_handler(component.device_group)
+        handler = self._get_handler(component.device_group)
         return handler.get_actions(component, action_type, *args)
 
-    @staticmethod
-    def _get_handler(device_group: str) -> BaseActionHandler:
+    def _get_handler(self, device_group: str) -> BaseActionHandler:
+        gw = self._gateway_id
         group = SfType(device_group)
         match group:
             case SfType.ACCESS:
-                return AccessActionHandler()
+                return AccessActionHandler(gw)
             case SfType.AUDIO:
-                return AudioActionHandler()
+                return AudioActionHandler(gw)
             case SfType.AUTOMATION:
-                return AutomationActionHandler()
+                return AutomationActionHandler(gw)
             case SfType.CLIMA:
-                return ClimaActionHandler()
+                return ClimaActionHandler(gw)
             case SfType.ENERGY:
-                return EnergyActionHandler()
+                return EnergyActionHandler(gw)
             case SfType.IRRIGATION:
-                return IrrigationActionHandler()
+                return IrrigationActionHandler(gw)
             case SfType.LIGHT:
-                return LightActionHandler()
+                return LightActionHandler(gw)
             case SfType.SCENE:
-                return SceneActionHandler()
+                return SceneActionHandler(gw)
             case SfType.SCENE_ACTIVATOR:
-                return SceneActivatorActionHandler()
+                return SceneActivatorActionHandler(gw)
             case SfType.SENSOR:
-                return SensorActionHandler()
+                return SensorActionHandler(gw)
             case SfType.SHUTTER:
-                return ShutterActionHandler()
+                return ShutterActionHandler(gw)
             case _:
                 raise NotImplementedError

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/audio/audio_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/audio/audio_action_handler.py
@@ -9,21 +9,25 @@ from .ss_audio_zone_action_handler import SsAudioZoneActionHandler
 
 
 class AudioActionHandler:
+    
+    def __init__(self, gateway_id: str) -> None:
+        self._gateway_id = gateway_id
+
     def get_actions(
         self, component: VimarComponent, action_type: ActionType, *args
     ) -> list[VimarAction]:
         handler = self.get_handler(component)
         return handler.get_actions(component, action_type, *args)
 
-    @staticmethod
-    def get_handler(component: VimarComponent) -> HandlerInterface:
+    def get_handler(self, component: VimarComponent) -> HandlerInterface:
+        gw = self._gateway_id
         sstype = component.device_name
         if sstype == SsAudioBluetoothActionHandler.SSTYPE:
-            return SsAudioBluetoothActionHandler()
+            return SsAudioBluetoothActionHandler(gw)
         if sstype == SsAudioRadioFmActionHandler.SSTYPE:
-            return SsAudioRadioFmActionHandler()
+            return SsAudioRadioFmActionHandler(gw)
         if sstype == SsAudioRcaActionHandler.SSTYPE:
-            return SsAudioRcaActionHandler()
+            return SsAudioRcaActionHandler(gw)
         if sstype == SsAudioZoneActionHandler.SSTYPE:
-            return SsAudioZoneActionHandler()
+            return SsAudioZoneActionHandler(gw)
         raise NotImplementedError

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/automation/automation_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/automation/automation_action_handler.py
@@ -9,17 +9,21 @@ from .ss_automation_output_control_action_handler import (
 
 
 class AutomationActionHandler:
+    
+    def __init__(self, gateway_id: str) -> None:
+        self._gateway_id = gateway_id
+
     def get_actions(
         self, component: VimarComponent, action_type: ActionType, *args
     ) -> list[VimarAction]:
         handler = self.get_handler(component)
         return handler.get_actions(component, action_type, *args)
 
-    @staticmethod
-    def get_handler(component: VimarComponent) -> HandlerInterface:
+    def get_handler(self, component: VimarComponent) -> HandlerInterface:
+        gw = self._gateway_id
         sstype = component.device_name
         if sstype == SsAutomationOnOffActionHandler.SSTYPE:
-            return SsAutomationOnOffActionHandler()
+            return SsAutomationOnOffActionHandler(gw)
         if sstype == SsAutomationOutputControlActionHandler.SSTYPE:
-            return SsAutomationOutputControlActionHandler()
+            return SsAutomationOutputControlActionHandler(gw)
         raise NotImplementedError

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/base_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/base_action_handler.py
@@ -22,10 +22,14 @@ class HandlerInterface(ABC):
 
 
 class BaseActionHandler(HandlerInterface):
-    _user_repo = Database.instance().user_repo
-    _ambient_repo = Database.instance().ambient_repo
-    _component_repo = Database.instance().component_repo
-    _element_repo = Database.instance().element_repo
+
+    def __init__(self, gateway_id: str) -> None:
+        db = Database.instance(gateway_id)
+        self._gateway_id = gateway_id
+        self._user_repo = db.user_repo
+        self._ambient_repo = db.ambient_repo
+        self._component_repo = db.component_repo
+        self._element_repo = db.element_repo
 
     def save_user_credentials(self, response: dict):
         credentials = UserCredentials.obj_from_dict(response)

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/energy/energy_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/energy/energy_action_handler.py
@@ -8,6 +8,10 @@ REAL_TIME = SfeType.CMD_TIMED_DYNAMIC_MODE
 
 
 class EnergyActionHandler:
+    
+    def __init__(self, gateway_id: str) -> None:
+        self._gateway_id = gateway_id
+
     def get_actions(
         self, component: VimarComponent, action_type: ActionType, *args
     ) -> list[VimarAction]:

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/light/light_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/light/light_action_handler.py
@@ -20,31 +20,35 @@ from .ss_light_switch_action_handler import SsLightSwitchActionHandler
 
 
 class LightActionHandler:
+    
+    def __init__(self, gateway_id: str) -> None:
+        self._gateway_id = gateway_id
+
     def get_actions(
         self, component: VimarComponent, action_type: ActionType, *args
     ) -> list[VimarAction]:
         handler = self.get_handler(component)
         return handler.get_actions(component, action_type, *args)
 
-    @staticmethod
-    def get_handler(component: VimarComponent) -> HandlerInterface:
+    def get_handler(self, component: VimarComponent) -> HandlerInterface:
+        gw = self._gateway_id
         sstype = component.device_name
         if sstype == SsLightSwitchActionHandler.SSTYPE:
-            return SsLightSwitchActionHandler()
+            return SsLightSwitchActionHandler(gw)
         if sstype == SsLightDimmerActionHandler.SSTYPE:
-            return SsLightDimmerActionHandler()
+            return SsLightDimmerActionHandler(gw)
         if sstype == SsLightDimmerRgbActionHandler.SSTYPE:
-            return SsLightDimmerRgbActionHandler()
+            return SsLightDimmerRgbActionHandler(gw)
         if sstype == SsLightDynamicDimmerActionHandler.SSTYPE:
-            return SsLightDynamicDimmerActionHandler()
+            return SsLightDynamicDimmerActionHandler(gw)
         if sstype == SsLightPhilipsDimmerActionHandler.SSTYPE:
-            return SsLightPhilipsDimmerActionHandler()
+            return SsLightPhilipsDimmerActionHandler(gw)
         if sstype == SsLightPhilipsDimmerRgbActionHandler.SSTYPE:
-            return SsLightPhilipsDimmerRgbActionHandler()
+            return SsLightPhilipsDimmerRgbActionHandler(gw)
         if sstype == SsLightPhilipsSwitchActionHandler.SSTYPE:
-            return SsLightPhilipsSwitchActionHandler()
+            return SsLightPhilipsSwitchActionHandler(gw)
         if sstype == SsLightPhilipsDynamicDimmerActionHandler.SSTYPE:
-            return SsLightPhilipsDynamicDimmerActionHandler()
+            return SsLightPhilipsDynamicDimmerActionHandler(gw)
         if sstype == SsLightPhilipsDynamicDimmerRgbActionHandler.SSTYPE:
-            return SsLightPhilipsDynamicDimmerRgbActionHandler()
+            return SsLightPhilipsDynamicDimmerRgbActionHandler(gw)
         raise NotImplementedError

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/scene/scene_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/scene/scene_action_handler.py
@@ -6,15 +6,19 @@ from .ss_scene_executor_action_handler import SsSceneExecutorActionHandler
 
 
 class SceneActionHandler:
+    
+    def __init__(self, gateway_id: str) -> None:
+        self._gateway_id = gateway_id
+
     def get_actions(
         self, component: VimarComponent, action_type: ActionType, *args
     ) -> list[VimarAction]:
         handler = self.get_handler(component)
         return handler.get_actions(component, action_type, *args)
 
-    @staticmethod
-    def get_handler(component: VimarComponent) -> HandlerInterface:
+    def get_handler(self, component: VimarComponent) -> HandlerInterface:
+        gw = self._gateway_id
         sstype = component.device_name
         if sstype == SsSceneExecutorActionHandler.SSTYPE:
-            return SsSceneExecutorActionHandler()
+            return SsSceneExecutorActionHandler(gw)
         raise NotImplementedError

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/scene_activator/scene_activator_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/scene_activator/scene_activator_action_handler.py
@@ -18,23 +18,27 @@ from .ss_scene_activator_video_entry_action_handler import (
 
 
 class SceneActivatorActionHandler:
+    
+    def __init__(self, gateway_id: str) -> None:
+        self._gateway_id = gateway_id
+
     def get_actions(
         self, component: VimarComponent, action_type: ActionType, *args
     ) -> list[VimarAction]:
         handler = self.get_handler(component)
         return handler.get_actions(component, action_type, *args)
 
-    @staticmethod
-    def get_handler(component: VimarComponent) -> HandlerInterface:
+    def get_handler(self, component: VimarComponent) -> HandlerInterface:
+        gw = self._gateway_id
         sstype = component.device_name
         if sstype == SsSceneActivatorActivatorActionHandler.SSTYPE:
-            return SsSceneActivatorActivatorActionHandler()
+            return SsSceneActivatorActivatorActionHandler(gw)
         if sstype == SsSceneActivatorAirQualityGradientActionHandler.SSTYPE:
-            return SsSceneActivatorAirQualityGradientActionHandler()
+            return SsSceneActivatorAirQualityGradientActionHandler(gw)
         if sstype == SsSceneActivatorSaiActionHandler.SSTYPE:
-            return SsSceneActivatorSaiActionHandler()
+            return SsSceneActivatorSaiActionHandler(gw)
         if sstype == SsSceneActivatorSaiG2ActionHandler.SSTYPE:
-            return SsSceneActivatorSaiG2ActionHandler()
+            return SsSceneActivatorSaiG2ActionHandler(gw)
         if sstype == SsSceneActivatorVideoEntryActionHandler.SSTYPE:
-            return SsSceneActivatorVideoEntryActionHandler()
+            return SsSceneActivatorVideoEntryActionHandler(gw)
         raise NotImplementedError

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/sensor/sensor_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/sensor/sensor_action_handler.py
@@ -8,18 +8,9 @@ REAL_TIME = SfeType.CMD_TIMED_DYNAMIC_MODE
 
 
 class SensorActionHandler:
-    # def get_actions(
-    #     self, component: VimarComponent, action_type: ActionType, *args
-    # ) -> list[VimarAction]:
-    #     handler = self.get_handler(component)
-    #     return handler.get_actions(component, action_type, *args)
 
-    # @staticmethod
-    # def get_handler(component: VimarComponent) -> HandlerInterface:
-    #     sstype = component.device_name
-    #     if sstype == SsSensorPowerActionHandler.SSTYPE:
-    #         return SsSensorPowerActionHandler()
-    #     raise NotImplementedError
+    def __init__(self, gateway_id: str) -> None:
+        self._gateway_id = gateway_id
 
     def get_actions(
         self, component: VimarComponent, action_type: ActionType, *args

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/shutter/shutter_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/shutter/shutter_action_handler.py
@@ -17,25 +17,29 @@ from .ss_shutter_without_position_action_handler import (
 
 
 class ShutterActionHandler:
+    
+    def __init__(self, gateway_id: str) -> None:
+        self._gateway_id = gateway_id
+
     def get_actions(
         self, component: VimarComponent, action_type: ActionType, *args
     ) -> list[VimarAction]:
         handler = self.get_handler(component)
         return handler.get_actions(component, action_type, *args)
 
-    @staticmethod
-    def get_handler(component: VimarComponent) -> HandlerInterface:
+    def get_handler(self, component: VimarComponent) -> HandlerInterface:
+        gw = self._gateway_id
         sstype = component.device_name
         if sstype == SsShutterPositionActionHandler.SSTYPE:
-            return SsShutterPositionActionHandler()
+            return SsShutterPositionActionHandler(gw)
         if sstype == SsShutterWithoutPositionActionHandler.SSTYPE:
-            return SsShutterWithoutPositionActionHandler()
+            return SsShutterWithoutPositionActionHandler(gw)
         if sstype == SsShutterSlatPositionActionHandler.SSTYPE:
-            return SsShutterSlatPositionActionHandler()
+            return SsShutterSlatPositionActionHandler(gw)
         if sstype == SsShutterSlatWithoutPositionActionHandler.SSTYPE:
-            return SsShutterSlatWithoutPositionActionHandler()
+            return SsShutterSlatWithoutPositionActionHandler(gw)
         if sstype == SsCurtainPositionActionHandler.SSTYPE:
-            return SsCurtainPositionActionHandler()
+            return SsCurtainPositionActionHandler(gw)
         if sstype == SsCurtainWithoutPositionActionHandler.SSTYPE:
-            return SsCurtainWithoutPositionActionHandler()
+            return SsCurtainWithoutPositionActionHandler(gw)
         raise NotImplementedError

--- a/custom_components/vimar_byme_plus/vimar/service/handler/error_handler/error_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/error_handler/error_handler.py
@@ -1,10 +1,10 @@
 import errno
 
+from ....database.database import Database
 from ....model.enum.error_response_enum import ErrorResponse
 from ....model.gateway.gateway_info import GatewayInfo
 from ....model.web_socket.base_request_response import BaseRequestResponse
 from ....model.web_socket.base_response import BaseResponse
-from ....utils.file import get_db_name, remove_file
 from ....utils.logger import log_error, log_info
 
 
@@ -52,9 +52,9 @@ class ErrorHandler:
         self.remove_database()
 
     def remove_database(self):
-        db_name = get_db_name()
-        log_info(__name__, f"Removing database {db_name} ...")
-        remove_file(db_name)
+        gw_id = self._gateway_info.deviceuid
+        log_info(__name__, f"Removing database for gateway {gw_id} ...")
+        Database.remove(gw_id, delete_file=True)
 
     def is_ssl_error(self, exception: Exception) -> bool:
         if not exception:

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/base_message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/base_message_handler.py
@@ -29,10 +29,14 @@ class HandlerInterface(ABC):
 
 
 class BaseMessageHandler(HandlerInterface):
-    _user_repo = Database.instance().user_repo
-    _ambient_repo = Database.instance().ambient_repo
-    _component_repo = Database.instance().component_repo
-    _element_repo = Database.instance().element_repo
+
+    def __init__(self, gateway_id: str) -> None:
+        db = Database.instance(gateway_id)
+        self._gateway_id = gateway_id
+        self._user_repo = db.user_repo
+        self._ambient_repo = db.ambient_repo
+        self._component_repo = db.component_repo
+        self._element_repo = db.element_repo
 
     def save_user_credentials(self, response: dict):
         credentials = UserCredentials.obj_from_dict(response)

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/message_handler.py
@@ -8,7 +8,7 @@ from ....model.web_socket.supporting_models.message_supporting_values import (
     MessageSupportingValues,
 )
 from ....utils.session_token import get_session_token
-from .base_handler_message import HandlerInterface
+from .base_message_handler import HandlerInterface
 from .phase.ambient_discovery_message_handler import AmbientDiscoveryMessageHandler
 from .phase.attach_message_handler import AttachMessageHandler
 from .phase.change_status_message_handler import ChangeStatusMessageHandler
@@ -26,11 +26,13 @@ from .phase.unknown_message_handler import UnknownMessageHandler
 
 class MessageHandler:
     _gateway_info: GatewayInfo
+    _gateway_id: str
     _last_msgid: int
     _token: str
 
     def __init__(self, gateway_info: GatewayInfo) -> None:
         self._gateway_info = gateway_info
+        self._gateway_id = gateway_info.deviceuid
         self._last_msgid = -1
         self._token = get_session_token()
 
@@ -60,7 +62,7 @@ class MessageHandler:
 
     def message_from_phase(self, phase: IntegrationPhase, *args) -> BaseRequestResponse:
         config = self._get_supporting_config(*args)
-        handler = MessageHandler._get_handler(phase)
+        handler = self._get_handler(phase)
         return handler.handle_message(None, config)
 
     def message_received(self, message: BaseRequestResponse) -> BaseRequestResponse:
@@ -68,7 +70,7 @@ class MessageHandler:
         self._save_msgid_if_needed(message)
         self._save_token_if_needed(phase, message)
         config = self._get_supporting_config()
-        handler = MessageHandler._get_handler(phase)
+        handler = self._get_handler(phase)
         return handler.handle_message(message, config)
 
     def clean(self):
@@ -99,32 +101,32 @@ class MessageHandler:
             idsf=args[0] if args else [],
         )
 
-    @staticmethod
-    def _get_handler(phase: IntegrationPhase) -> HandlerInterface:
+    def _get_handler(self, phase: IntegrationPhase) -> HandlerInterface:
+        gw = self._gateway_id
         match phase:
             case IntegrationPhase.INIT:
-                return InitMessageHandler()
+                return InitMessageHandler(gw)
             case IntegrationPhase.SESSION:
-                return SessionMessageHandler()
+                return SessionMessageHandler(gw)
             case IntegrationPhase.ATTACH:
-                return AttachMessageHandler()
+                return AttachMessageHandler(gw)
             case IntegrationPhase.AMBIENT_DISCOVERY:
-                return AmbientDiscoveryMessageHandler()
+                return AmbientDiscoveryMessageHandler(gw)
             case IntegrationPhase.SF_DISCOVERY:
-                return SfDiscoveryMessageHandler()
+                return SfDiscoveryMessageHandler(gw)
             case IntegrationPhase.DO_ACTION:
-                return DoActionMessageHandler()
+                return DoActionMessageHandler(gw)
             case IntegrationPhase.CHANGE_STATUS:
-                return ChangeStatusMessageHandler()
+                return ChangeStatusMessageHandler(gw)
             case IntegrationPhase.EXPIRE:
-                return ExpireMessageHandler()
+                return ExpireMessageHandler(gw)
             case IntegrationPhase.REGISTER:
-                return RegisterMessageHandler()
+                return RegisterMessageHandler(gw)
             case IntegrationPhase.GET_STATUS:
-                return GetStatusMessageHandler()
+                return GetStatusMessageHandler(gw)
             case IntegrationPhase.KEEP_ALIVE:
-                return KeepAliveMessageHandler()
+                return KeepAliveMessageHandler(gw)
             case IntegrationPhase.DETACH:
-                return DetachMessageHandler()
+                return DetachMessageHandler(gw)
             case _:
-                return UnknownMessageHandler()
+                return UnknownMessageHandler(gw)

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/ambient_discovery_message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/ambient_discovery_message_handler.py
@@ -4,7 +4,7 @@ from .....model.web_socket.supporting_models.message_supporting_values import (
     MessageSupportingValues,
 )
 from .....utils.logger import log_info
-from ..base_handler_message import BaseMessageHandler
+from ..base_message_handler import BaseMessageHandler
 
 
 class AmbientDiscoveryMessageHandler(BaseMessageHandler):

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/attach_message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/attach_message_handler.py
@@ -6,7 +6,7 @@ from .....model.web_socket.supporting_models.message_supporting_values import (
     MessageSupportingValues,
 )
 from .....utils.logger import log_info
-from ..base_handler_message import BaseMessageHandler
+from ..base_message_handler import BaseMessageHandler
 
 
 class AttachMessageHandler(BaseMessageHandler):

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/change_status_message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/change_status_message_handler.py
@@ -4,7 +4,7 @@ from .....model.web_socket.supporting_models.message_supporting_values import (
     MessageSupportingValues,
 )
 from .....utils.logger import log_debug
-from ..base_handler_message import BaseMessageHandler
+from ..base_message_handler import BaseMessageHandler
 
 
 class ChangeStatusMessageHandler(BaseMessageHandler):

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/detach_message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/detach_message_handler.py
@@ -3,7 +3,7 @@ from .....model.web_socket.request.detach_request import DetachRequest
 from .....model.web_socket.supporting_models.message_supporting_values import (
     MessageSupportingValues,
 )
-from ..base_handler_message import BaseMessageHandler
+from ..base_message_handler import BaseMessageHandler
 
 
 class DetachMessageHandler(BaseMessageHandler):

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/do_action_message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/do_action_message_handler.py
@@ -4,7 +4,7 @@ from .....model.web_socket.supporting_models.message_supporting_values import (
     MessageSupportingValues,
 )
 from .....utils.logger import log_info
-from ..base_handler_message import BaseMessageHandler
+from ..base_message_handler import BaseMessageHandler
 
 
 class DoActionMessageHandler(BaseMessageHandler):

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/expire_message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/expire_message_handler.py
@@ -4,7 +4,7 @@ from .....model.web_socket.supporting_models.message_supporting_values import (
     MessageSupportingValues,
 )
 from .....utils.logger import log_info
-from ..base_handler_message import BaseMessageHandler
+from ..base_message_handler import BaseMessageHandler
 
 
 class ExpireMessageHandler(BaseMessageHandler):

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/get_status_message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/get_status_message_handler.py
@@ -4,7 +4,7 @@ from .....model.web_socket.supporting_models.message_supporting_values import (
     MessageSupportingValues,
 )
 from .....utils.logger import log_info
-from ..base_handler_message import BaseMessageHandler
+from ..base_message_handler import BaseMessageHandler
 
 
 class GetStatusMessageHandler(BaseMessageHandler):

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/init_message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/init_message_handler.py
@@ -5,7 +5,7 @@ from .....model.web_socket.supporting_models.message_supporting_values import (
 )
 from .....utils.logger import log_debug
 from .....utils.session_token import get_session_token
-from ..base_handler_message import BaseMessageHandler
+from ..base_message_handler import BaseMessageHandler
 
 
 class InitMessageHandler(BaseMessageHandler):

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/keep_alive_message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/keep_alive_message_handler.py
@@ -4,7 +4,7 @@ from .....model.web_socket.supporting_models.message_supporting_values import (
     MessageSupportingValues,
 )
 from .....utils.logger import log_info
-from ..base_handler_message import BaseMessageHandler
+from ..base_message_handler import BaseMessageHandler
 
 
 class KeepAliveMessageHandler(BaseMessageHandler):

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/register_message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/register_message_handler.py
@@ -2,7 +2,7 @@ from .....model.web_socket.base_request_response import BaseRequestResponse
 from .....model.web_socket.supporting_models.message_supporting_values import (
     MessageSupportingValues,
 )
-from ..base_handler_message import BaseMessageHandler
+from ..base_message_handler import BaseMessageHandler
 
 
 class RegisterMessageHandler(BaseMessageHandler):

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/session_message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/session_message_handler.py
@@ -4,7 +4,7 @@ from .....model.web_socket.supporting_models.message_supporting_values import (
     MessageSupportingValues,
 )
 from .....utils.logger import log_debug
-from ..base_handler_message import BaseMessageHandler
+from ..base_message_handler import BaseMessageHandler
 
 
 class SessionMessageHandler(BaseMessageHandler):

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/sf_discovery_message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/sf_discovery_message_handler.py
@@ -4,7 +4,7 @@ from .....model.web_socket.supporting_models.message_supporting_values import (
     MessageSupportingValues,
 )
 from .....utils.logger import log_info
-from ..base_handler_message import BaseMessageHandler
+from ..base_message_handler import BaseMessageHandler
 
 
 class SfDiscoveryMessageHandler(BaseMessageHandler):

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/unknown_message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/unknown_message_handler.py
@@ -4,7 +4,7 @@ from .....model.web_socket.supporting_models.message_supporting_values import (
     MessageSupportingValues,
 )
 from .....utils.logger import log_error
-from ..base_handler_message import BaseMessageHandler
+from ..base_message_handler import BaseMessageHandler
 
 
 class UnknownMessageHandler(BaseMessageHandler):

--- a/custom_components/vimar_byme_plus/vimar/service/operational_service.py
+++ b/custom_components/vimar_byme_plus/vimar/service/operational_service.py
@@ -7,6 +7,7 @@ from websocket import WebSocketConnectionClosedException
 from ..client.web_service.sync_session_phase import SyncSessionPhase
 from ..client.web_service.ws_attach_phase import WSAttachPhase
 from ..database.database import Database
+from ..database.repository.user_repo import UserRepo
 from ..model.component.vimar_component import VimarComponent
 from ..model.enum.action_type import ActionType
 from ..model.enum.integration_phase import IntegrationPhase
@@ -49,7 +50,7 @@ class OperationalService:
     _keep_alive_handler: KeepAliveHandler
 
     _web_socket: WSAttachPhase = None
-    _user_repo = Database.instance().user_repo
+    _user_repo: UserRepo
 
     def __init__(self, gateway_info: GatewayInfo, callback: Update) -> None:
         """Initialize Vimar intagration."""
@@ -57,10 +58,12 @@ class OperationalService:
         self.session_port = gateway_info.port
         self.gateway_info = gateway_info
         self.update_callback = callback
-        self._action_handler = ActionHandler()
+        self._user_repo = Database.instance(gateway_info.deviceuid).user_repo
+        self._action_handler = ActionHandler(gateway_info.deviceuid)
         self._error_handler = ErrorHandler(gateway_info)
         self._message_handler = MessageHandler(gateway_info)
         self._keep_alive_handler = KeepAliveHandler()
+        
         # Watchdog timestamp: monotonic seconds of the last activity from
         # the gateway. The HA-side Coordinator polls this to detect
         # silent-stale state (TCP up but no messages flowing).

--- a/custom_components/vimar_byme_plus/vimar/utils/file.py
+++ b/custom_components/vimar_byme_plus/vimar/utils/file.py
@@ -38,14 +38,6 @@ def get_file_path(file_name: str) -> str:
     return get_data_path() + file_name
 
 
-def get_db_name() -> str:
-    path = get_data_path()
-    for file_name in os.listdir(path):
-        if file_name.endswith(".db"):
-            return file_name
-    return None
-
-
 def get_data_path() -> str:
     return _get_data_path() + "/"
 


### PR DESCRIPTION
## Summary

Refactors the persistence layer from a single global `home.db` + `Database` singleton to a **per-gateway database registry**, so the integration can support multiple Vimar gateways concurrently in the same Home Assistant instance.

Each gateway now owns a dedicated `home_<deviceuid>.db` file. `Database.instance(gateway_id)` returns the per-gateway instance from a thread-safe registry. Every code path that previously resolved repositories at import time via `Database.instance().<repo>` now resolves them at construction time, parameterized on the gateway the consumer serves.

Existing single-gateway installs migrate automatically on first startup with a transparent `os.rename(home.db, home_<gw_id>.db)`. No data loss, no schema change.

## Why per-gateway and not a shared DB

Considered both approaches. Per-gateway wins on three axes:

1. **SQLite write-lock contention**. SQLite serializes writes per file. Two coordinators receiving `change_status` concurrently on a shared DB would queue on the same write lock; per-gateway files eliminate the contention by construction.
2. **Failure isolation**. Corruption or a stale lock on one gateway's file does not affect the other gateways.
3. **Schema simplicity**. No `gateway_id` column to thread through every `WHERE` clause, no risk of cross-gateway data leak from a missing filter, and migration for existing users is a single `os.rename` instead of `ALTER TABLE` + backfill on four tables.

## Main Changes

```python
# Before
class Database:
    _instance: Optional["Database"] = None
    @classmethod
    def instance(cls): ...

# After
class Database:
    _instances: dict[str, "Database"] = {}
    _instances_lock = threading.Lock()

    @classmethod
    def instance(cls, gateway_id: str) -> "Database": ...

```


The class-attribute pattern that resolved repositories at module load time becomes an instance-level lookup at construction time, parameterized on gateway_info.deviceuid. The same shift applies to every consumer of the Database singleton.

```python
# Before
class VimarClient:
    _component_repo = Database.instance().component_repo

# After
class VimarClient:
    def __init__(self, gateway_info, callback):
        db = Database.instance(gateway_info.deviceuid)
        self._component_repo = db.component_repo

```