### PR TITLE
fix: scope entity unique_id per gateway to avoid multi-gateway collis…

### DIFF
--- a/custom_components/vimar_byme_plus/__init__.py
+++ b/custom_components/vimar_byme_plus/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from functools import partial
 
 import voluptuous as vol
@@ -10,8 +11,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 
 from .const import DOMAIN, GATEWAY_ID
+
+_LOGGER = logging.getLogger(__name__)
 from .coordinator import Coordinator
 from .vimar.database.database import Database
 from .vimar.model.exceptions import CodeNotValidException, VimarErrorResponseException
@@ -60,6 +64,66 @@ async def async_unload_entry(
         entry.runtime_data.stop()
     entry.runtime_data = None
     return unload_ok
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate to v2: scope every entity's unique_id by gateway deviceuid.
+
+    `base_entity.unique_id` now embeds the gateway uid
+    (`vimar_byme_plus_<gw_uid>_app_<idsf>`) to avoid cross-gateway idsf
+    collisions. Existing installs created before this change hold the legacy
+    `vimar_byme_plus_app_<idsf>` ids; without this migration those entities
+    would be orphaned (unavailable) and brand-new ones created at boot,
+    losing every user customisation.
+
+    Design is deliberately minimal: only `unique_id` is rewritten.
+    entity_id, friendly name, area, device, icon — everything else is left
+    untouched. The migration is idempotent (already-scoped ids are skipped)
+    and defensive (a registry ValueError on one entity is logged and the
+    loop continues; that entity simply keeps its legacy id).
+    """
+    if entry.version >= 2:
+        return True
+
+    gateway_uid = entry.data.get(GATEWAY_ID)
+    if not gateway_uid:
+        _LOGGER.warning(
+            "Migration: entry %s has no gateway id, skipping unique_id rescoping",
+            entry.entry_id,
+        )
+        hass.config_entries.async_update_entry(entry, version=2)
+        return True
+
+    legacy_prefix = f"{DOMAIN}_app_"
+    new_prefix = f"{DOMAIN}_{gateway_uid}_app_"
+
+    registry = er.async_get(hass)
+    entities = er.async_entries_for_config_entry(registry, entry.entry_id)
+
+    migrated = skipped = failed = 0
+    for ent in entities:
+        uid = ent.unique_id
+        if not uid.startswith(legacy_prefix):
+            skipped += 1
+            continue
+        new_uid = new_prefix + uid[len(legacy_prefix):]
+        try:
+            registry.async_update_entity(ent.entity_id, new_unique_id=new_uid)
+            migrated += 1
+        except ValueError as err:
+            _LOGGER.warning(
+                "Migration: cannot rescope %s (%s -> %s): %s",
+                ent.entity_id, uid, new_uid, err,
+            )
+            failed += 1
+
+    _LOGGER.info(
+        "Migration entry %s (gateway %s): rescoped %d, already-ok %d, failed %d",
+        entry.entry_id, gateway_uid, migrated, skipped, failed,
+    )
+
+    hass.config_entries.async_update_entry(entry, version=2)
+    return True
 
 
 async def _async_options_updated(

--- a/custom_components/vimar_byme_plus/base_entity.py
+++ b/custom_components/vimar_byme_plus/base_entity.py
@@ -44,8 +44,25 @@ class BaseEntity(CoordinatorEntity):
 
     @property
     def unique_id(self):
-        """Return unique id of the device."""
-        return DOMAIN + "_app_" + str(self._component.id)
+        """Return unique id of the device, scoped per gateway.
+
+        With per-gateway databases (PR #72) each gateway's `idsf` space is
+        independent, so `idsf` is NOT globally unique across gateways: e.g.
+        idsf 1003 is "Applique ingresso" on one gateway and "luce cucina"
+        on another. The previous `vimar_byme_plus_app_<idsf>` therefore
+        produced identical unique_ids for two different entities on two
+        gateways; Home Assistant keeps only the first and silently drops the
+        second ("Platform vimar_byme_plus does not generate unique IDs").
+        Including the gateway deviceuid makes them distinct. Single-gateway
+        installs are migrated by `async_migrate_entry` so existing entity
+        customisations are preserved (see __init__.py).
+        """
+        gw_uid = getattr(self.coordinator, "gateway_info", None)
+        if gw_uid is not None:
+            gw_uid = getattr(gw_uid, "deviceuid", None)
+        if gw_uid:
+            return f"{DOMAIN}_{gw_uid}_app_{self._component.id}"
+        return f"{DOMAIN}_app_{self._component.id}"
 
     @property
     def is_default_state(self):

--- a/custom_components/vimar_byme_plus/config_flow.py
+++ b/custom_components/vimar_byme_plus/config_flow.py
@@ -45,7 +45,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     discovery_info: zeroconf.ZeroconfServiceInfo = None
 
-    VERSION = 1
+    # v2: entity unique_ids are scoped per gateway deviceuid (see
+    # base_entity.unique_id and async_migrate_entry in __init__.py).
+    VERSION = 2
 
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 


### PR DESCRIPTION
…ions

With per-gateway databases (#72) each gateway has an independent idsf space, so idsf is no longer unique across gateways (e.g. idsf 1003 maps to different devices on two gateways). The previous vimar_byme_plus_app_<idsf> therefore generated identical unique_ids for distinct entities on different gateways; Home Assistant keeps the first and silently drops the second ("Platform vimar_byme_plus does not generate unique IDs"). Only visible with 2+ paired gateways.

Scope the unique_id by coordinator.gateway_info.deviceuid: vimar_byme_plus_<deviceuid>_app_<idsf> (with a safe fallback to the legacy format when the uid is unavailable).

Add async_migrate_entry (config flow VERSION 1 -> 2) to rewrite existing entities' unique_ids to the scoped format. Migration is minimal (only unique_id touched - entity_id, name, area, device left intact), idempotent and defensive, so single-gateway installs keep all customisations.