### PR TITLE
fix: wind speed of 0 m/s reported as unavailable

### DIFF
--- a/custom_components/vimar_byme_plus/vimar/mapper/sensor/ss_sensor_wind_speed_mapper.py
+++ b/custom_components/vimar_byme_plus/vimar/mapper/sensor/ss_sensor_wind_speed_mapper.py
@@ -33,7 +33,9 @@ class SsSensorWindSpeedMapper(SsSensorGenericMapper):
 
     def get_kmh(self, component: UserComponent) -> Decimal | None:
         value = self.native_value(component)
-        if not value:
+        # Explicit None check: Decimal("0.0") is falsy, so a truthiness test
+        # turns calm weather (0 m/s) into an unavailable sensor.
+        if value is None:
             return None
         return value * Decimal("3.6")
 


### PR DESCRIPTION
## Problem

`sensor.<weather_station>_wind` goes to `unknown` whenever the wind speed is exactly `0`, i.e. on every calm day. On my installation the entity spent **96 % of 2026-08-24 in `unknown`**, with a single stretch of 7 hours. It looks like a broken sensor, but the gateway is delivering data the whole time.

The gateway value is fine — read directly from the integration's own SQLite store while Home Assistant showed `unknown`:

```
sfetype                   value    updated
SFE_State_WindSpeed       0.0      2026-08-24 10:32:15
```

## Cause

`get_kmh()` rejects the converted value with a truthiness check:

```python
def get_kmh(self, component: UserComponent) -> Decimal | None:
    value = self.native_value(component)
    if not value:                 # Decimal("0.0") is falsy
        return None
    return value * Decimal("3.6")
```

`native_value()` returns `Decimal("0.0")` for a calm reading, and `Decimal("0.0")` is falsy, so the mapper reports "no value" instead of `0 km/h`.

This is specific to the wind mapper: it is the only one that re-checks the value *after* the `Decimal` conversion (needed for the m/s → km/h conversion added for #28). Every other mapper tests the raw string coming out of `UserComponent.get_value()`, where `"0.0"` is truthy and zero survives.

## Fix

Test for `None` explicitly — that is what `native_value()` actually returns when the gateway sends nothing:

```python
if value is None:
    return None
```

## Effect

- Calm weather now reports `0 km/h` instead of `unknown`
- Long-term statistics and history stop being full of gaps
- Missing values are still reported as unavailable, unchanged

Verified on v3.2.1 against a By-me Plus weather station (`SS_Sensor_WeatherStation`).
