### PR TITLE
fix: venetian blind slats

### DIFF
--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/shutter/ss_shutter_slat_position_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/shutter/ss_shutter_slat_position_action_handler.py
@@ -22,6 +22,24 @@ class SsShutterSlatPositionActionHandler(SsShutterPositionActionHandler):
             return self.get_set_slat_position_actions(component.id, args[0])
         return super().get_actions(component, action_type, *args)
 
+    def get_open_cover_actions(self, id: str) -> list[VimarAction]:
+        """Raise the blind AND tilt the slats open, in one message.
+
+        Issue #90: on a venetian blind the two are one gesture. Vimar opens
+        the slats while the blind rises and closes them while it comes down;
+        sending only the travel command left the slats wherever they were, so
+        a blind lowered from Home Assistant ended up shut but with the light
+        still coming through — something the Vimar app never does.
+
+        One `doaction` carries both, the same way the dimmer already sends
+        on + brightness together.
+        """
+        return [*super().get_open_cover_actions(id), *self.get_open_slat_actions(id)]
+
+    def get_close_cover_actions(self, id: str) -> list[VimarAction]:
+        """Lower the blind AND tilt the slats closed. See get_open_cover_actions."""
+        return [*super().get_close_cover_actions(id), *self.get_close_slat_actions(id)]
+
     def get_open_slat_actions(self, id: str) -> list[VimarAction]:
         """Open the cover slat."""
         return [self._action(id, SLAT, "0")]

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/shutter/ss_shutter_slat_position_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/shutter/ss_shutter_slat_position_action_handler.py
@@ -23,21 +23,11 @@ class SsShutterSlatPositionActionHandler(SsShutterPositionActionHandler):
         return super().get_actions(component, action_type, *args)
 
     def get_open_cover_actions(self, id: str) -> list[VimarAction]:
-        """Raise the blind AND tilt the slats open, in one message.
-
-        Issue #90: on a venetian blind the two are one gesture. Vimar opens
-        the slats while the blind rises and closes them while it comes down;
-        sending only the travel command left the slats wherever they were, so
-        a blind lowered from Home Assistant ended up shut but with the light
-        still coming through — something the Vimar app never does.
-
-        One `doaction` carries both, the same way the dimmer already sends
-        on + brightness together.
-        """
+        """Raise the blind AND tilt the slats open."""
         return [*super().get_open_cover_actions(id), *self.get_open_slat_actions(id)]
 
     def get_close_cover_actions(self, id: str) -> list[VimarAction]:
-        """Lower the blind AND tilt the slats closed. See get_open_cover_actions."""
+        """Lower the blind AND tilt the slats closed."""
         return [*super().get_close_cover_actions(id), *self.get_close_slat_actions(id)]
 
     def get_open_slat_actions(self, id: str) -> list[VimarAction]:

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/shutter/ss_shutter_slat_without_position_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/shutter/ss_shutter_slat_without_position_action_handler.py
@@ -23,16 +23,11 @@ class SsShutterSlatWithoutPositionActionHandler(SsShutterWithoutPositionActionHa
         return super().get_actions(component, action_type, *args)
 
     def get_open_cover_actions(self, id: str) -> list[VimarAction]:
-        """Raise the blind AND tilt the slats open, in one message (issue #90).
-
-        Same reasoning as the positioned variant: travel and tilt are one
-        gesture on a venetian blind, and sending only the travel command left
-        the slats where they were.
-        """
+        """Raise the blind AND tilt the slats open"""
         return [*super().get_open_cover_actions(id), *self.get_open_slat_actions(id)]
 
     def get_close_cover_actions(self, id: str) -> list[VimarAction]:
-        """Lower the blind AND tilt the slats closed. See get_open_cover_actions."""
+        """Lower the blind AND tilt the slats closed."""
         return [*super().get_close_cover_actions(id), *self.get_close_slat_actions(id)]
 
     def get_open_slat_actions(self, id: str) -> list[VimarAction]:

--- a/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/shutter/ss_shutter_slat_without_position_action_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/action_handler/shutter/ss_shutter_slat_without_position_action_handler.py
@@ -22,6 +22,19 @@ class SsShutterSlatWithoutPositionActionHandler(SsShutterWithoutPositionActionHa
             return self.get_close_slat_actions(component.id)
         return super().get_actions(component, action_type, *args)
 
+    def get_open_cover_actions(self, id: str) -> list[VimarAction]:
+        """Raise the blind AND tilt the slats open, in one message (issue #90).
+
+        Same reasoning as the positioned variant: travel and tilt are one
+        gesture on a venetian blind, and sending only the travel command left
+        the slats where they were.
+        """
+        return [*super().get_open_cover_actions(id), *self.get_open_slat_actions(id)]
+
+    def get_close_cover_actions(self, id: str) -> list[VimarAction]:
+        """Lower the blind AND tilt the slats closed. See get_open_cover_actions."""
+        return [*super().get_close_cover_actions(id), *self.get_close_slat_actions(id)]
+
     def get_open_slat_actions(self, id: str) -> list[VimarAction]:
         """Open the cover slat."""
         return [self._action(id, SLAT, "Open")]


### PR DESCRIPTION
On a Venetian blind, movement and tilt are a single gesture: Vimar opens the slats as the shutter rises and closes them as it lowers.
The integration used to send only the movement command, so a shutter lowered from Home Assistant stayed down with the slats wherever they were—effectively open—and you had to close them manually using the tilt slider.
OPEN and CLOSE now also include the slat command in the same doaction message.