### PR TITLE
fix: ask the gateway for one sfcategory per sfdiscovery request

### DIFF
--- a/custom_components/vimar_byme_plus/vimar/model/web_socket/request/sf_discovery_request.py
+++ b/custom_components/vimar_byme_plus/vimar/model/web_socket/request/sf_discovery_request.py
@@ -6,17 +6,19 @@ from ..supporting_models.parameter import Parameter
 
 @dataclass
 class SfDiscoveryRequest(BaseRequest):
-    def __init__(self, target: str, token: str, ambient_ids: list[str]):
+    def __init__(
+        self, target: str, token: str, ambient_ids: list[str], sfcategory: str
+    ):
         super().__init__()
         self.function = "sfdiscovery"
         self.target = target
         self.token = token
         self.msgid = "2"
-        self.args = self.get_args()
+        self.args = self.get_args(sfcategory)
         self.params = self.get_params(ambient_ids)
 
-    def get_args(self) -> list:
-        return [self.get_category("Plant"), self.get_category("LogicProgram")]
+    def get_args(self, sfcategory: str) -> list:
+        return [self.get_category(sfcategory)]
 
     def get_category(self, value: str) -> dict:
         return {"sfcategory": value}

--- a/custom_components/vimar_byme_plus/vimar/model/web_socket/supporting_models/message_supporting_values.py
+++ b/custom_components/vimar_byme_plus/vimar/model/web_socket/supporting_models/message_supporting_values.py
@@ -12,3 +12,4 @@ class MessageSupportingValues:
     protocol_version: str
     actions: list[VimarAction]
     idsf: int
+    sfcategory: str | None = None

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/base_message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/base_message_handler.py
@@ -46,10 +46,13 @@ class BaseMessageHandler(HandlerInterface):
         log_info(__name__, f"Ambients retrieved: {len(ambients)}")
         self._ambient_repo.replace_all(ambients)
 
-    def save_components(self, response: dict):
+    def clear_components(self):
+        self._component_repo.delete_all()
+
+    def add_components(self, response: dict):
         components = UserComponent.list_from_response(response)
         log_info(__name__, f"Components retrieved: {len(components)}")
-        self._component_repo.replace_all(components)
+        self._component_repo.insert_all(components)
 
     def save_component_changes(self, request: dict):
         components = UserComponent.list_from_request(request)

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/message_handler.py
@@ -23,18 +23,25 @@ from .phase.session_message_handler import SessionMessageHandler
 from .phase.sf_discovery_message_handler import SfDiscoveryMessageHandler
 from .phase.unknown_message_handler import UnknownMessageHandler
 
+# The gateway honours only the FIRST sfcategory of an sfdiscovery
+# request and silently ignores the remaining ones, so every category has
+# to be asked for in its own request.
+SF_CATEGORIES: tuple[str, ...] = ("Plant", "LogicProgram")
+
 
 class MessageHandler:
     _gateway_info: GatewayInfo
     _gateway_id: str
     _last_msgid: int
     _token: str
+    _pending_sf_categories: list[str]
 
     def __init__(self, gateway_info: GatewayInfo) -> None:
         self._gateway_info = gateway_info
         self._gateway_id = gateway_info.deviceuid
         self._last_msgid = -1
         self._token = get_session_token()
+        self._pending_sf_categories = list(SF_CATEGORIES)
 
     def start_session_phase(self) -> BaseRequest:
         phase = IntegrationPhase.INIT
@@ -67,6 +74,7 @@ class MessageHandler:
 
     def message_received(self, message: BaseRequestResponse) -> BaseRequestResponse:
         phase = self._get_phase(message)
+        self._complete_sf_category_if_needed(phase)
         self._save_msgid_if_needed(message)
         self._save_token_if_needed(phase, message)
         config = self._get_supporting_config()
@@ -76,9 +84,21 @@ class MessageHandler:
     def clean(self):
         self._last_msgid = -1
         self._token = get_session_token()
+        self._pending_sf_categories = list(SF_CATEGORIES)
 
     def _get_phase(self, message: BaseRequestResponse) -> IntegrationPhase:
         return IntegrationPhase.get(message.function)
+
+    def _complete_sf_category_if_needed(self, phase: IntegrationPhase):
+        """Drop the category whose sfdiscovery response just arrived."""
+        if phase == IntegrationPhase.SF_DISCOVERY and self._pending_sf_categories:
+            self._pending_sf_categories.pop(0)
+
+    def _next_sf_category(self) -> str | None:
+        """Return the category the next sfdiscovery has to ask for."""
+        if not self._pending_sf_categories:
+            return None
+        return self._pending_sf_categories[0]
 
     def _save_msgid_if_needed(self, message: BaseRequestResponse):
         if message.msgid:
@@ -99,6 +119,7 @@ class MessageHandler:
             protocol_version=self._gateway_info.protocolversion,
             actions=args[0] if args else [],
             idsf=args[0] if args else [],
+            sfcategory=self._next_sf_category(),
         )
 
     def _get_handler(self, phase: IntegrationPhase) -> HandlerInterface:

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/ambient_discovery_message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/ambient_discovery_message_handler.py
@@ -16,6 +16,7 @@ class AmbientDiscoveryMessageHandler(BaseMessageHandler):
             "Ambient Discovery Phase completed, sending SF Discovery Request...",
         )
         self.save_ambients(message)
+        self.clear_components()
         return self.get_sf_discovery_request(config)
 
     def get_sf_discovery_request(
@@ -25,4 +26,5 @@ class AmbientDiscoveryMessageHandler(BaseMessageHandler):
             target=config.target,
             token=config.token,
             ambient_ids=self.get_all_ambient_ids(),
+            sfcategory=config.sfcategory,
         )

--- a/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/sf_discovery_message_handler.py
+++ b/custom_components/vimar_byme_plus/vimar/service/handler/message_handler/phase/sf_discovery_message_handler.py
@@ -1,5 +1,6 @@
 from .....model.web_socket.base_request_response import BaseRequestResponse
 from .....model.web_socket.request.register_request import RegisterRequest
+from .....model.web_socket.request.sf_discovery_request import SfDiscoveryRequest
 from .....model.web_socket.supporting_models.message_supporting_values import (
     MessageSupportingValues,
 )
@@ -11,9 +12,28 @@ class SfDiscoveryMessageHandler(BaseMessageHandler):
     def handle_message(
         self, message: BaseRequestResponse, config: MessageSupportingValues
     ) -> BaseRequestResponse:
+        self.add_components(message)
+
+        if config.sfcategory:
+            log_info(
+                __name__,
+                f"SF Discovery Phase done for one category, "
+                f"asking for '{config.sfcategory}'...",
+            )
+            return self.get_sf_discovery_request(config)
+
         log_info(__name__, "SF Discovery Phase completed, sending Register Request...")
-        self.save_components(message)
         return self.get_register_request(config)
+
+    def get_sf_discovery_request(
+        self, config: MessageSupportingValues
+    ) -> SfDiscoveryRequest:
+        return SfDiscoveryRequest(
+            target=config.target,
+            token=config.token,
+            ambient_ids=self.get_all_ambient_ids(),
+            sfcategory=config.sfcategory,
+        )
 
     def get_register_request(self, config: MessageSupportingValues) -> RegisterRequest:
         return RegisterRequest(


### PR DESCRIPTION
## Problem

`SfDiscoveryRequest` asks for both categories in a single message:

```python
return [self.get_category("Plant"), self.get_category("LogicProgram")]
```

The gateway, however, evaluates only the **first** `sfcategory` and silently ignores the rest — no error, just a shorter answer. Measured against my plant (gateway AG+, firmware `0.3.5-gitca05edb`, SF model `v1.13.0`, protocol 3.0) by sending the four variants over a separate session:

| request | answer |
|---|---|
| `args=[Plant, LogicProgram]` ← what the integration sends | 153 SFs, **no** logic program |
| `args=[LogicProgram, Plant]` | 13 SFs, only logic programs |
| `args=[Plant]` | 153 SFs |
| `args=[LogicProgram]` | 13 SFs |

So the `SF_LogicProgram` functions of the plant never arrive: they are missing from the local database, are never part of the `register` request, and cannot be mapped to entities by any future mapper.

## Fix

Ask for one category per request:

- `SfDiscoveryRequest` takes a single `sfcategory`.
- `MessageHandler` keeps the remaining categories in a small queue (`SF_CATEGORIES`), resets it in `clean()` and drops one whenever an `sfdiscovery` response arrives; the next category is handed to the handlers through `MessageSupportingValues.sfcategory`.
- `SfDiscoveryMessageHandler` stores the components it received and then either asks for the next category or, when none is left, sends the `register` request as before.
- Because the components of several responses now have to add up, `save_components` (replace) became `add_components` (append), and the component table is cleared once per cycle when `ambientdiscovery` completes.

No behaviour changes for a plant without logic programs, apart from one additional round trip during discovery.

## Testing

Offline, driving `MessageHandler` with recorded gateway responses: the request order is `ambientdiscovery` → `sfdiscovery[Plant]` → `sfdiscovery[LogicProgram]` → `register`, all components end up in the database, and a second cycle does not duplicate them.

Live on the plant above (Home Assistant 2026.9.1, restart plus config entry reload):

```
14:19:53  REQ sfdiscovery args=[{'sfcategory': 'Plant'}]
14:19:53  Components retrieved: 153
14:19:53  REQ sfdiscovery args=[{'sfcategory': 'LogicProgram'}]
14:19:53  Components retrieved: 13
14:19:53  REQ register: 166 components, 13 of them logic programs
          e.g. {"idsf": 30000, "sfetype": ["SFE_Cmd_Program", "SFE_State_Program", "SFE_State_ProgramId"]}
```

The database holds 166 components afterwards (153 + 13 `SF_LogicProgram`). Existing entities are unaffected — 59 lights, 30 covers, 44 buttons as before — and no errors appear in the log. Since no mapper claims `SF_LogicProgram`, the new components create no entities yet.

## Follow-up (not in this PR)

The attach response lists the categories the third-party user is allowed to discover: `["BigData", "ConfGateway", "InfoGateway", "LogicProgram", "Plant"]`. On my plant the other three answer with zero functions, but adding them to `SF_CATEGORIES` is now a one-line change if they turn out to carry data elsewhere. A mapper for `SS_LogicProgram_MainProgram` / `SS_LogicProgram_PeriodicProgram` (state `Running`, plus `SFE_Cmd_Program`) would be the natural next step to expose logic programs as entities.